### PR TITLE
car create, update, delete test코드 추가 및 코드 수정

### DIFF
--- a/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
+++ b/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
@@ -59,19 +59,20 @@ public class CarService {
     public CarDetailDto createCar( // 차량 등록
             CarRequestDto carRequest
     ) {
-        if (carReader.findByCarNumber(carRequest.getCarNumber()).isPresent()) {
-            throw new CarAlreadyExistsException("차량 번호가 이미 존재합니다: " + carRequest.getCarNumber());
-        }
+        boolean isCarNumberExists = carReader.findByCarNumber(carRequest.getCarNumber()).isPresent();
+        boolean isEmulatorIdExists = carReader.findByEmulatorId(carRequest.getEmulatorId()).isPresent();
 
-        if (carReader.findByEmulatorId(carRequest.getEmulatorId()).isPresent()) {
-            throw new CarAlreadyExistsException("해당 Emulator ID가 이미 사용 중입니다: " + carRequest.getEmulatorId());
+        if (isCarNumberExists || isEmulatorIdExists) {
+            throw new CarAlreadyExistsException(
+                    isCarNumberExists ? carRequest.getCarNumber() : null,
+                    isEmulatorIdExists ? carRequest.getEmulatorId() : null
+            );
         }
         var entity = CarEntity.builder()
                 .brand(carRequest.getBrand())
                 .model(carRequest.getModel())
                 .carYear(carRequest.getCarYear())
-//                .status(CarStatus.IDLE) // default값 : 대기 중
-                .status(carRequest.getStatus())
+                .status(CarStatus.IDLE) // default값 : 대기 중
                 .carType(carRequest.getCarType())
                 .carNumber(carRequest.getCarNumber())
                 .sumDist(carRequest.getSumDist())
@@ -101,8 +102,8 @@ public class CarService {
             entity.setCarYear(carRequest.getCarYear());
         }
 
-        if(carRequest.getStatus() != null && !carRequest.getStatus().name().isBlank()) {
-            var status = CarStatus.fromDisplayName(carRequest.getStatus().getDisplayName());
+        if(carRequest.getStatus() != null && !carRequest.getStatus().isBlank()) {
+            var status = CarStatus.fromDisplayName(carRequest.getStatus());
             entity.setStatus(status);
         }
 
@@ -119,6 +120,9 @@ public class CarService {
         }
 
         if (carRequest.getEmulatorId() != null) {
+            if (carReader.findByEmulatorId(carRequest.getEmulatorId()).isPresent()) {
+                throw new CarAlreadyExistsException(null, carRequest.getEmulatorId());
+            }
             entity.setEmulatorId(carRequest.getEmulatorId());
         }
 

--- a/back/src/main/java/com/example/_thecore_back/car/controller/dto/CarDeleteDto.java
+++ b/back/src/main/java/com/example/_thecore_back/car/controller/dto/CarDeleteDto.java
@@ -1,6 +1,8 @@
 package com.example._thecore_back.car.controller.dto;
 
 import com.example._thecore_back.car.domain.CarEntity;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 @Getter
@@ -9,6 +11,8 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+
 public class CarDeleteDto {
     private String model;
     private String brand;

--- a/back/src/main/java/com/example/_thecore_back/car/controller/dto/CarDetailDto.java
+++ b/back/src/main/java/com/example/_thecore_back/car/controller/dto/CarDetailDto.java
@@ -18,7 +18,7 @@ public class CarDetailDto {
 
     private String model;
 
-    private Integer year;
+    private Integer carYear;
 
     private String status;
 
@@ -33,8 +33,8 @@ public class CarDetailDto {
         return CarDetailDto.builder()
                 .brand(car.getBrand())
                 .model(car.getModel())
-                .year(car.getCarYear())
-                .status(car.getStatus().name())
+                .carYear(car.getCarYear())
+                .status(car.getStatus().getDisplayName())
                 .carType(car.getCarType())
                 .carNumber(car.getCarNumber())
                 .sumDist(car.getSumDist())

--- a/back/src/main/java/com/example/_thecore_back/car/controller/dto/CarRequestDto.java
+++ b/back/src/main/java/com/example/_thecore_back/car/controller/dto/CarRequestDto.java
@@ -21,7 +21,7 @@ public class CarRequestDto {
 
     private Integer carYear;
 
-    private CarStatus status;
+    private String status;
 
     @NotBlank(groups = CreateGroup.class)
     private String carType;

--- a/back/src/main/java/com/example/_thecore_back/car/exception/CarAlreadyExistsException.java
+++ b/back/src/main/java/com/example/_thecore_back/car/exception/CarAlreadyExistsException.java
@@ -1,7 +1,19 @@
 package com.example._thecore_back.car.exception;
 
 public class CarAlreadyExistsException extends RuntimeException {
-    public CarAlreadyExistsException(String message) {
-      super(message);
+    public CarAlreadyExistsException(String carNumber, Integer emulatorId) {
+        super(buildMessage(carNumber, emulatorId));
+    }
+
+    private static String buildMessage(String carNumber, Integer emulatorId) {
+        if (carNumber != null && emulatorId != null) {
+            return String.format("이미 등록된 차량입니다. (차량 번호: %s, 에뮬레이터 ID: %d)", carNumber, emulatorId);
+        } else if (carNumber != null) {
+            return String.format("이미 등록된 차량 번호입니다: %s", carNumber);
+        } else if (emulatorId != null) {
+            return String.format("이미 등록된 에뮬레이터 ID입니다: %d", emulatorId);
+        } else {
+            return "이미 등록된 차량입니다.";
+        }
     }
 }

--- a/back/src/main/java/com/example/_thecore_back/car/exception/CarExceptionHandler.java
+++ b/back/src/main/java/com/example/_thecore_back/car/exception/CarExceptionHandler.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,7 +22,7 @@ public class CarExceptionHandler {
 
     // 차량이 이미 존재할 때 - create
     @ExceptionHandler(CarAlreadyExistsException.class)
-    public ApiResponse<CarExceptionResponse> handleCarAlreadyExistsException(CarAlreadyExistsException e, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<CarExceptionResponse>> handleCarAlreadyExistsException(CarAlreadyExistsException e, HttpServletRequest request) {
         var response = CarExceptionResponse.builder()
                 .timestamp(LocalDateTime.now())
                 .status(HttpStatus.CONFLICT.value())
@@ -30,21 +31,25 @@ public class CarExceptionHandler {
                 .path(request.getRequestURI())
                 .build();
 
-        return ApiResponse.fail(response);
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT.value())
+                .body(ApiResponse.fail(response));
     }
 
     // 차량이 존재하지 않을 때
     @ExceptionHandler(CarNotFoundException.class)
-    public ApiResponse<CarExceptionResponse> handleCarNotFoundException(CarNotFoundException e, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<CarExceptionResponse>> handleCarNotFoundException(CarNotFoundException e, HttpServletRequest request) {
 
         var response = CarExceptionResponse.builder()
                 .timestamp(LocalDateTime.now())
-                .status(HttpStatus.BAD_REQUEST.value())
-                .error(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                .status(HttpStatus.NOT_FOUND.value())
+                .error(HttpStatus.NOT_FOUND.getReasonPhrase())
                 .message(e.getMessage())
                 .path(request.getRequestURI())
                 .build();
 
-        return ApiResponse.fail(response);
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND.value())
+                .body(ApiResponse.fail(response));
     }
 }

--- a/back/src/main/java/com/example/_thecore_back/car/exception/response/CarExceptionResponse.java
+++ b/back/src/main/java/com/example/_thecore_back/car/exception/response/CarExceptionResponse.java
@@ -1,5 +1,6 @@
 package com.example._thecore_back.car.exception.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
+++ b/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
@@ -1,0 +1,291 @@
+package com.example._thecore_back.car;
+
+import com.example._thecore_back.car.application.CarService;
+import com.example._thecore_back.car.controller.CarController;
+import com.example._thecore_back.car.controller.dto.CarDeleteDto;
+import com.example._thecore_back.car.controller.dto.CarDetailDto;
+import com.example._thecore_back.car.controller.dto.CarRequestDto;
+import com.example._thecore_back.car.exception.CarAlreadyExistsException;
+import com.example._thecore_back.car.exception.CarNotFoundException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CarController.class)
+public class CarControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CarService carService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("POST - 차량 등록 컨트롤러 Test")
+    void createCarSuccess() throws Exception {
+        // 요청 객체 생성
+        CarRequestDto request = CarRequestDto.builder()
+                .brand("현대")
+                .model("아반떼")
+                .carYear(2025)
+                .carType("중형")
+                .carNumber("12가3456")
+                .sumDist(1234.56)
+                .emulatorId(1)
+                .build();
+
+        // 응답 객체 생성
+        CarDetailDto response = CarDetailDto.builder()
+                .brand("현대")
+                .model("아반떼")
+                .carYear(2025)
+                .status("대기")
+                .carType("중형")
+                .carNumber("12가3456")
+                .sumDist(1234.56)
+                .build();
+
+        // 기대 return 형식 지정
+        when(carService.createCar(any(CarRequestDto.class)))
+                .thenReturn(response);
+
+        // test 실행
+        ResultActions actions = mockMvc.perform(post("/api/vehicles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)));
+
+        // 결과 검증
+        actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.brand").value("현대"))
+                .andExpect(jsonPath("$.data.model").value("아반떼"))
+                .andExpect(jsonPath("$.data.car_year").value(2025))
+                .andExpect(jsonPath("$.data.status").value("대기"))
+                .andExpect(jsonPath("$.data.car_type").value("중형"))
+                .andExpect(jsonPath("$.data.car_number").value("12가3456"))
+                .andExpect(jsonPath("$.data.sum_dist").value(1234.56));
+    }
+
+    @Test
+    @DisplayName("PATCH - 차량 정보 수정 컨트롤러 Test")
+    void updateCarSuccess() throws Exception {
+        CarRequestDto request = CarRequestDto.builder()
+                .carYear(2015)
+                .status("운행")
+                .carNumber("6543나21")
+                .build();
+
+        CarDetailDto response = CarDetailDto.builder()
+                .brand("현대")
+                .model("아반떼")
+                .carYear(2015)
+                .status("운행")
+                .carType("중형")
+                .carNumber("6543나21")
+                .sumDist(1234.56)
+                .build();
+
+        when(carService.updateCar(any(CarRequestDto.class), any(String.class)))
+                .thenReturn(response);
+
+        ResultActions actions = mockMvc.perform(patch("/api/vehicles/1234가56")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)));
+
+        actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.car_year").value(2015))
+                .andExpect(jsonPath("$.data.status").value("운행"))
+                .andExpect(jsonPath("$.data.car_number").value("6543나21"));
+    }
+
+    @Test
+    @DisplayName("DELETE - 차량 삭제 컨트롤러 Test")
+    void deleteCarSuccess() throws Exception {
+        CarDeleteDto response = CarDeleteDto.builder()
+                .brand("현대")
+                .model("아반떼")
+                .carNumber("6543나21")
+                .build();
+
+        when(carService.deleteCar(any(String.class)))
+                .thenReturn(response);
+
+        ResultActions actions = mockMvc.perform(delete("/api/vehicles/6543나21"));
+
+        actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.brand").value("현대"))
+                .andExpect(jsonPath("$.data.model").value("아반떼"))
+                .andExpect(jsonPath("$.data.car_number").value("6543나21"));
+    }
+
+    // 예외처리 Test Code
+    @Test
+    @DisplayName("POST - 차량 등록 실패: 차량 번호 중복")
+    void createCarFailCarNum() throws Exception {
+        CarRequestDto request = CarRequestDto.builder()
+                .brand("현대")
+                .model("아반떼")
+                .carYear(2025)
+                .carType("중형")
+                .carNumber("12가3456")
+                .sumDist(1234.56)
+                .emulatorId(1)
+                .build();
+
+        when(carService.createCar(any(CarRequestDto.class)))
+                .thenThrow(new CarAlreadyExistsException("12가3456", null));
+
+        ResultActions actions = mockMvc.perform(post("/api/vehicles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        actions
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.result").value(false))
+                .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
+                .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
+                .andExpect(jsonPath("$.data.message").value("이미 등록된 차량 번호입니다: 12가3456"))
+                .andExpect(jsonPath("$.data.path").value("/api/vehicles"));
+    }
+
+    @Test
+    @DisplayName("POST - 차량 등록 실패: 애뮬레이터 번호 중복")
+    void createCarFailEmulatorNum() throws Exception {
+        CarRequestDto request = CarRequestDto.builder()
+                .brand("현대")
+                .model("아반떼")
+                .carYear(2025)
+                .carType("중형")
+                .carNumber("12가3456")
+                .sumDist(1234.56)
+                .emulatorId(1)
+                .build();
+
+        when(carService.createCar(any(CarRequestDto.class)))
+                .thenThrow(new CarAlreadyExistsException(null, 1));
+
+        ResultActions actions = mockMvc.perform(post("/api/vehicles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        actions
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.result").value(false))
+                .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
+                .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
+                .andExpect(jsonPath("$.data.message").value("이미 등록된 에뮬레이터 ID입니다: 1"))
+                .andExpect(jsonPath("$.data.path").value("/api/vehicles"));
+    }
+
+    @Test
+    @DisplayName("POST - 차량 등록 실패: 차량 번호 및 애뮬레이터 ID 중복")
+    void createCarFailBoth() throws Exception {
+        CarRequestDto request = CarRequestDto.builder()
+                .brand("현대")
+                .model("아반떼")
+                .carYear(2025)
+                .carType("중형")
+                .carNumber("12가3456")
+                .sumDist(1234.56)
+                .emulatorId(1)
+                .build();
+
+        when(carService.createCar(any(CarRequestDto.class)))
+                .thenThrow(new CarAlreadyExistsException("12가3456", 1));
+
+        ResultActions actions = mockMvc.perform(post("/api/vehicles")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        actions
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.result").value(false))
+                .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
+                .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
+                .andExpect(jsonPath("$.data.message").value("이미 등록된 차량입니다. (차량 번호: 12가3456, 에뮬레이터 ID: 1)"))
+                .andExpect(jsonPath("$.data.path").value("/api/vehicles"));
+    }
+
+    @Test
+    @DisplayName("PATCH - 차량 정보 수정 실패: 애뮬레이터 번호 중복")
+    void updateCarFailEmulatorNum() throws Exception {
+        CarRequestDto request = CarRequestDto.builder()
+                .carYear(2015)
+                .status("운행")
+                .carNumber("6543나21")
+                .emulatorId(1)
+                .build();
+
+        when(carService.updateCar(any(CarRequestDto.class), any(String.class)))
+                .thenThrow(new CarAlreadyExistsException(null, 1));
+
+        ResultActions actions = mockMvc.perform(patch("/api/vehicles/1234가56")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        actions
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.result").value(false))
+                .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
+                .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
+                .andExpect(jsonPath("$.data.message").value("이미 등록된 에뮬레이터 ID입니다: 1"));
+    }
+
+
+    @Test
+    @DisplayName("PATCH - 차량 정보 수정 실패: 존재하지 않는 차량")
+    void updateCarFailNotFound() throws Exception {
+        CarRequestDto request = CarRequestDto.builder()
+                .carYear(2015)
+                .status("운행")
+                .carNumber("6543나21")
+                .build();
+
+        when(carService.updateCar(any(CarRequestDto.class), any(String.class)))
+                .thenThrow(new CarNotFoundException("1234가56"));
+
+        ResultActions actions = mockMvc.perform(patch("/api/vehicles/1234가56")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        actions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.result").value(false))
+                .andExpect(jsonPath("$.data.status").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.data.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+                .andExpect(jsonPath("$.data.message").value("해당 차량 ( 1234가56 )은 존재하지 않습니다. 다시 입력해주세요"));
+    }
+
+    @Test
+    @DisplayName("DELETE - 차량 삭제 실패: 존재하지 않는 차량")
+    void deleteCarFail() throws Exception {
+        when(carService.deleteCar("9999가99"))
+                .thenThrow(new CarNotFoundException("9999가99"));
+
+        ResultActions actions = mockMvc.perform(delete("/api/vehicles/9999가99"));
+
+        actions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.result").value(false))
+                .andExpect(jsonPath("$.data.status").value(HttpStatus.NOT_FOUND.value()))
+                .andExpect(jsonPath("$.data.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+                .andExpect(jsonPath("$.data.message").value("해당 차량 ( 9999가99 )은 존재하지 않습니다. 다시 입력해주세요"));
+    }
+}


### PR DESCRIPTION
1. **Test code 추가**
    - create, update, delete 컨트롤러에 대한 기본 테스트
    - create 시 차량 번호 혹은 애뮬레이터 번호가 존재할 경우 예외처리 테스트
    - update 시 존재하는 애뮬레이터 번호로 변경하려할 경우 예외처리 테스트
    - update, delete 시 존재하지 않는 차량을 삭제하려할 경우 예외처리 테스트
2. **Exception에 맞는 상태코드 return하게 변경**
    - 기존에는 Exception 발생해도 status는 200으로 전송됨
    - 해당 부분을 발생한 예외에 맞는 상태코드로 return하도록 변경함
3. 차량 생성 시 기본 상태값 추가
    - 기존에는 응답으로 받았으나 수정 후에는 응답으로 받지않고 default값으로 `CarStatus.IDLE`(대기) 상태 부여
4. CarDetailDto
    - year 변수명 carYear로 변경
    - status response로 넘겨줄 때 ‘대기’, ‘운행’, ‘수리’로 넘겨주기 위해 코드 수정
        - `.name()` 메소드를 `.getDisplayName()` 으로 수정
5. CarAlreadyExistsExeption
    - 애뮬레이터 번호, 차량번호 중복일 경우에 대한 특정 메세지 출력 로직으로 변경
    - 두 필드 모두 중복일 경우와 하나의 필드만 중복일 경우 구분해서 메세지 출력
6. CarDeleteDto에 Snake case 출력을 위한 annotation추가
    - `@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.*class*)`