### PR TITLE
fix: Mockbean 제거, MockitoBean으로 대체

### DIFF
--- a/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
+++ b/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -29,7 +29,7 @@ public class CarControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private CarService carService;
 
     @Autowired


### PR DESCRIPTION
- spring boot 3.4 이상에서 지원하지 않는 MockBean을 MockitoBean으로 대체