### PR TITLE
[#29] fix: 차량 정보 수정 시 중복된 차량 번호에 대한 예외 처리 및 이에 따른 테스트 코드 추가 

### DIFF
--- a/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
+++ b/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
@@ -104,8 +104,14 @@ public class CarService {
             CarRequestDto carRequest,
             String carNumber
     ) {
+        // 수정하려는 차량이 존재하지 않는 경우
         CarEntity entity = carReader.findByCarNumber(carNumber)
                     .orElseThrow(() -> new CarNotFoundException(CarErrorCode.CAR_NOT_FOUND_BY_NUMBER, carNumber));
+
+        // 차량 번호가 이미 존재할 경우
+        if(carReader.findByCarNumber(carRequest.getCarNumber()).isPresent()){
+            throw new CarAlreadyExistsException(carRequest.getCarNumber());
+        }
 
         entity.updateInfo(carRequest); // Entity 내부에서 유효성 검사 후 업데이트
 

--- a/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
+++ b/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
@@ -1,6 +1,8 @@
 package com.example._thecore_back.car.application;
 
 
+import com.example._thecore_back.car.domain.CarReader;
+import com.example._thecore_back.car.domain.CarWriter;
 import com.example._thecore_back.car.exception.CarAlreadyExistsException;
 import com.example._thecore_back.car.controller.dto.CarDeleteDto;
 import com.example._thecore_back.car.controller.dto.CarDetailDto;
@@ -9,8 +11,6 @@ import com.example._thecore_back.car.controller.dto.CarSummaryDto;
 import com.example._thecore_back.car.exception.CarErrorCode;
 import com.example._thecore_back.car.exception.CarNotFoundByFilterException;
 import com.example._thecore_back.car.exception.CarNotFoundException;
-import com.example._thecore_back.car.infrastructure.CarReaderImpl;
-import com.example._thecore_back.car.infrastructure.CarWriterImpl;
 import com.example._thecore_back.car.infrastructure.mapper.CarMapper;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +27,8 @@ import com.example._thecore_back.car.controller.dto.CarRequestDto;
 @RequiredArgsConstructor
 public class CarService {
 
-    private final CarReaderImpl carReader;
-    private final CarWriterImpl carWriter;
+    private final CarReader carReader;
+    private final CarWriter carWriter;
     private final CarMapper carMapper;
 
     public CarDetailDto getCar(String carNumber){
@@ -107,34 +107,7 @@ public class CarService {
         CarEntity entity = carReader.findByCarNumber(carNumber)
                     .orElseThrow(() -> new CarNotFoundException(CarErrorCode.CAR_NOT_FOUND_BY_NUMBER, carNumber));
 
-        if (carRequest.getBrand() != null && !carRequest.getBrand().isBlank()) {
-            entity.setBrand(carRequest.getBrand());
-        }
-
-        if(carRequest.getModel() != null && !carRequest.getModel().isBlank()) {
-            entity.setModel(carRequest.getModel());
-        }
-
-        if(carRequest.getCarYear() != null && !carRequest.getCarYear().equals(0)) {
-            entity.setCarYear(carRequest.getCarYear());
-        }
-
-        if(carRequest.getStatus() != null && !carRequest.getStatus().isBlank()) {
-            var status = CarStatus.fromDisplayName(carRequest.getStatus());
-            entity.setStatus(status);
-        }
-
-        if(carRequest.getCarType() != null && !carRequest.getCarType().isBlank()) {
-            entity.setCarType(carRequest.getCarType());
-        }
-
-        if(carRequest.getCarNumber() != null && !carRequest.getCarNumber().isBlank()) {
-            entity.setCarNumber(carRequest.getCarNumber());
-        }
-
-        if (carRequest.getSumDist() != null && carRequest.getSumDist() >= 0) {
-            entity.setSumDist(carRequest.getSumDist());
-        }
+        entity.updateInfo(carRequest); // Entity 내부에서 유효성 검사 후 업데이트
 
         return CarDetailDto.EntityToDto(carWriter.save(entity));
     }

--- a/back/src/main/java/com/example/_thecore_back/car/controller/CarController.java
+++ b/back/src/main/java/com/example/_thecore_back/car/controller/CarController.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/vehicles")
+@RequestMapping("/api/cars")
 public class CarController {
 
     private final CarService carService;
@@ -33,7 +33,7 @@ public class CarController {
         return ApiResponse.success(response);
     }
 
-    @GetMapping("")
+    @GetMapping
     public ApiResponse<List<CarSearchDto>> getAllCars() {
 
         var response = carService.getAllCars();
@@ -68,7 +68,7 @@ public class CarController {
     }
 
     // 차량 등록
-    @PostMapping("")
+    @PostMapping
     public ApiResponse<CarDetailDto> createCar(
             @RequestBody
             @Validated(CreateGroup.class)

--- a/back/src/main/java/com/example/_thecore_back/car/domain/CarEntity.java
+++ b/back/src/main/java/com/example/_thecore_back/car/domain/CarEntity.java
@@ -1,5 +1,7 @@
 package com.example._thecore_back.car.domain;
 
+import com.example._thecore_back.car.controller.dto.CarDetailDto;
+import com.example._thecore_back.car.controller.dto.CarRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -38,5 +40,34 @@ public class CarEntity {
 
     private Integer emulatorId; // 연결된 애뮬레이터 아이디
 
+    public void updateInfo(CarRequestDto carRequest) {
+        if (carRequest.getBrand() != null && !carRequest.getBrand().isBlank()) {
+            setBrand(carRequest.getBrand());
+        }
 
+        if(carRequest.getModel() != null && !carRequest.getModel().isBlank()) {
+            setModel(carRequest.getModel());
+        }
+
+        if(carRequest.getCarYear() != null && !carRequest.getCarYear().equals(0)) {
+            setCarYear(carRequest.getCarYear());
+        }
+
+        if(carRequest.getStatus() != null && !carRequest.getStatus().isBlank()) {
+            var status = CarStatus.fromDisplayName(carRequest.getStatus());
+            setStatus(status);
+        }
+
+        if(carRequest.getCarType() != null && !carRequest.getCarType().isBlank()) {
+            setCarType(carRequest.getCarType());
+        }
+
+        if(carRequest.getCarNumber() != null && !carRequest.getCarNumber().isBlank()) {
+            setCarNumber(carRequest.getCarNumber());
+        }
+
+        if (carRequest.getSumDist() != null && carRequest.getSumDist() >= 0) {
+            setSumDist(carRequest.getSumDist());
+        }
+    }
 }

--- a/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
+++ b/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
@@ -68,7 +68,7 @@ public class CarControllerTest {
                 .thenReturn(response);
 
         // test 실행
-        ResultActions actions = mockMvc.perform(post("/api/vehicles")
+        ResultActions actions = mockMvc.perform(post("/api/cars")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)));
 
@@ -106,7 +106,7 @@ public class CarControllerTest {
         when(carService.updateCar(any(CarRequestDto.class), any(String.class)))
                 .thenReturn(response);
 
-        ResultActions actions = mockMvc.perform(patch("/api/vehicles/1234가56")
+        ResultActions actions = mockMvc.perform(patch("/api/cars/1234가56")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)));
 
@@ -129,7 +129,7 @@ public class CarControllerTest {
         when(carService.deleteCar(any(String.class)))
                 .thenReturn(response);
 
-        ResultActions actions = mockMvc.perform(delete("/api/vehicles/6543나21"));
+        ResultActions actions = mockMvc.perform(delete("/api/cars/6543나21"));
 
         actions
                 .andExpect(status().isOk())
@@ -154,7 +154,7 @@ public class CarControllerTest {
         when(carService.createCar(any(CarRequestDto.class)))
                 .thenThrow(new CarAlreadyExistsException("12가3456"));
 
-        ResultActions actions = mockMvc.perform(post("/api/vehicles")
+        ResultActions actions = mockMvc.perform(post("/api/cars")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
 
@@ -164,7 +164,7 @@ public class CarControllerTest {
                 .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
                 .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
                 .andExpect(jsonPath("$.data.message").value("이미 등록된 차량입니다: 12가3456"))
-                .andExpect(jsonPath("$.data.path").value("/api/vehicles"));
+                .andExpect(jsonPath("$.data.path").value("/api/cars"));
     }
 
     @Test
@@ -179,7 +179,7 @@ public class CarControllerTest {
         when(carService.updateCar(any(CarRequestDto.class), any(String.class)))
                 .thenThrow(new CarNotFoundException(CarErrorCode.CAR_NOT_FOUND_BY_NUMBER, "1234가56"));
 
-        ResultActions actions = mockMvc.perform(patch("/api/vehicles/1234가56")
+        ResultActions actions = mockMvc.perform(patch("/api/cars/1234가56")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
 
@@ -192,12 +192,36 @@ public class CarControllerTest {
     }
 
     @Test
+    @DisplayName("PATCH - 차량 정보 수정 실패: 이미 존재하는 차량 번호")
+    void updateCarFailAlreadyExists() throws Exception {
+        CarRequestDto request = CarRequestDto.builder()
+                .carYear(2015)
+                .status("운행")
+                .carNumber("6543나21")
+                .build();
+
+        when(carService.updateCar(any(CarRequestDto.class), any(String.class)))
+                .thenThrow(new CarAlreadyExistsException("6543나21"));
+
+        ResultActions actions = mockMvc.perform(patch("/api/cars/1234가56")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        actions
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.result").value(false))
+                .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
+                .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
+                .andExpect(jsonPath("$.data.message").value("이미 등록된 차량입니다: 6543나21"));
+    }
+
+    @Test
     @DisplayName("DELETE - 차량 삭제 실패: 존재하지 않는 차량")
     void deleteCarFail() throws Exception {
         when(carService.deleteCar("9999가99"))
                 .thenThrow(new CarNotFoundException(CarErrorCode.CAR_NOT_FOUND_BY_NUMBER, "9999가99"));
 
-        ResultActions actions = mockMvc.perform(delete("/api/vehicles/9999가99"));
+        ResultActions actions = mockMvc.perform(delete("/api/cars/9999가99"));
 
         actions
                 .andExpect(status().isNotFound())
@@ -218,7 +242,7 @@ public class CarControllerTest {
 
         when(carService.getCar("12가1234")).thenReturn(response);
 
-        mockMvc.perform(get("/api/vehicles/12가1234"))
+        mockMvc.perform(get("/api/cars/12가1234"))
                 .andDo(print())
                 .andExpect(jsonPath("$.data.car_number").value("12가1234"))
                 .andExpect(jsonPath("$.data.model").value("아이오닉"));
@@ -226,7 +250,7 @@ public class CarControllerTest {
 
         when(carService.getCar("1234")).thenThrow(new CarNotFoundException(CarErrorCode.CAR_NOT_FOUND_BY_NUMBER,"1234"));
 
-        mockMvc.perform(get("/api/vehicles/1234"))
+        mockMvc.perform(get("/api/cars/1234"))
                 .andDo(print())
                 .andExpect(jsonPath("$.data.status").value(404))
                 .andExpect(jsonPath("$.data.message").value("해당 차량 ( 1234 )은 존재하지 않습니다. 다시 입력해주세요"));
@@ -241,7 +265,7 @@ public class CarControllerTest {
 
         when(carService.getAllCars()).thenReturn(carList);
 
-        mockMvc.perform(get("/api/vehicles"))
+        mockMvc.perform(get("/api/cars"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -256,7 +280,7 @@ public class CarControllerTest {
         // 차량이 존재하지 않을때
         when(carService.getAllCars()).thenThrow(new CarNotFoundException(CarErrorCode.NO_REGISTERED_CAR));
 
-        mockMvc.perform(get("/api/vehicles"))
+        mockMvc.perform(get("/api/cars"))
                 .andDo(print())
                 .andExpect(jsonPath("$.data.status").value(404))
                 .andExpect(jsonPath("$.data.message").value("등록된 차량이 존재하지 않습니다."));
@@ -280,7 +304,7 @@ public class CarControllerTest {
 
         when(carService.getCountByStatus()).thenReturn(response);
 
-        mockMvc.perform(get("/api/vehicles/statistics"))
+        mockMvc.perform(get("/api/cars/statistics"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.total").value(3L))
@@ -301,7 +325,7 @@ public class CarControllerTest {
         // 전체 조회
         when(carService.getCarsByFilter(null, null, null, null)).thenReturn(carList);
 
-        mockMvc.perform(get("/api/vehicles/search"))
+        mockMvc.perform(get("/api/cars/search"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(3));
@@ -312,7 +336,7 @@ public class CarControllerTest {
 
         when(carService.getCarsByFilter(null, null, "기아", null)).thenReturn(kiaCars);
 
-        mockMvc.perform(get("/api/vehicles/search").param("brand", "기아"))
+        mockMvc.perform(get("/api/cars/search").param("brand", "기아"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -324,7 +348,7 @@ public class CarControllerTest {
 
         when(carService.getCarsByFilter("12가3423", null, null, null)).thenReturn(carByNumber);
 
-        mockMvc.perform(get("/api/vehicles/search").param("carNumber", "12가3423"))
+        mockMvc.perform(get("/api/cars/search").param("carNumber", "12가3423"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(1))
@@ -337,7 +361,7 @@ public class CarControllerTest {
 
         when(carService.getCarsByFilter(null, null, null, CarStatus.IDLE)).thenReturn(carByStatusInIdle);
 
-        mockMvc.perform(get("/api/vehicles/search").param("status", CarStatus.IDLE.name()))
+        mockMvc.perform(get("/api/cars/search").param("status", CarStatus.IDLE.name()))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -349,7 +373,7 @@ public class CarControllerTest {
 
         when(carService.getCarsByFilter(null, "아이오닉", "기아", null)).thenReturn(carByBrandAndModel);
 
-        mockMvc.perform(get("/api/vehicles/search").param("brand", "기아")
+        mockMvc.perform(get("/api/cars/search").param("brand", "기아")
                         .param("model", "아이오닉"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
@@ -364,7 +388,7 @@ public class CarControllerTest {
     public void getCarsByFilterFailed() throws Exception {
         when(carService.getCarsByFilter(null, "삼성", null, null)).thenThrow(new CarNotFoundByFilterException());
 
-        mockMvc.perform(get("/api/vehicles/search").param("model", "삼성"))
+        mockMvc.perform(get("/api/cars/search").param("model", "삼성"))
                 .andDo(print())
                 .andExpect(jsonPath("$.data.status").value(400))
                 .andExpect(jsonPath("$.data.message").value("해당 조건으로 검색된 차가 존재하지 않습니다."));

--- a/back/src/test/java/com/example/_thecore_back/car/CarServiceTest.java
+++ b/back/src/test/java/com/example/_thecore_back/car/CarServiceTest.java
@@ -182,17 +182,6 @@ public class CarServiceTest {
                 .status("운행")
                 .build();
 
-        // 저장될 Entity 생성
-        CarEntity carEntity = CarEntity.builder()
-                .brand("현대")
-                .model("아반떼")
-                .carYear(2015)
-                .carType("중형")
-                .carNumber("12가3456")
-                .sumDist(1234.56)
-                .status(CarStatus.IN_USE)
-                .build();
-
         when(carReader.findByCarNumber("12가3456")).thenReturn(Optional.empty());
 
         // when & then
@@ -202,18 +191,38 @@ public class CarServiceTest {
     }
 
     @Test
+    @DisplayName("updateCar Test - fail: 이미 존재하는 차량 번호")
+    void updateCarFailAlreadyExists() {
+        String originalCarNumber = "12가3456"; // 기존 차량
+        String duplicateCarNumber = "99가9999"; // 중복 번호
+
+        // 요청 객체 생성
+        CarRequestDto request = CarRequestDto.builder()
+                .carYear(2015)
+                .status("운행")
+                .carNumber(duplicateCarNumber)
+                .build();
+
+        CarEntity alreadyExistingCar = CarEntity.builder()
+                .carNumber(duplicateCarNumber)
+                .build();
+
+        CarEntity targetCar = CarEntity.builder()
+                .carNumber(originalCarNumber)
+                .build();
+
+        when(carReader.findByCarNumber(originalCarNumber)).thenReturn(Optional.of(targetCar));
+        when(carReader.findByCarNumber(duplicateCarNumber)).thenReturn(Optional.of(alreadyExistingCar));
+
+        // when & then
+        assertThrows(CarAlreadyExistsException.class, () -> {
+            carService.updateCar(request, originalCarNumber);
+        });
+    }
+
+    @Test
     @DisplayName("deleteCar Test - fail: 존재하지 않는 차량 번호 조회")
     void deleteCarFail() {
-        // 저장될 Entity 생성
-        CarEntity carEntity = CarEntity.builder()
-                .brand("현대")
-                .model("아반떼")
-                .carYear(2025)
-                .carType("중형")
-                .carNumber("12가3456")
-                .sumDist(1234.56)
-                .status(CarStatus.IDLE)
-                .build();
 
         when(carReader.findByCarNumber("12가3456")).thenReturn(Optional.empty());
 


### PR DESCRIPTION
### 수정사항
**1. `CarService`의 `updateCar`에 중복된 차량 번호에 대한 예외처리 로직 추가**
**2. `CarControllerTest`**
&nbsp; - 해당 예외처리에 대한 테스트코드 추가
&nbsp; - API 경로 수정 : `api/vehicles` -> `/api/cars`
**3.  `CarServiceTest`**
&nbsp; - 해당 예외처리에 대한 테스트코드 추가
&nbsp; - 불필요한 코드 삭제 : 예외처리 테스트 코드의 Entity 생성 코드

### 관련 이슈
#29 