### PR TITLE
refractor: getCountByStatus의 로직을 CarReaderImpl로 수정

### DIFF
--- a/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
+++ b/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
@@ -9,7 +9,7 @@ import com.example._thecore_back.car.controller.dto.CarDetailDto;
 import com.example._thecore_back.car.controller.dto.CarSearchDto;
 import com.example._thecore_back.car.controller.dto.CarSummaryDto;
 import com.example._thecore_back.car.exception.CarErrorCode;
-import com.example._thecore_back.car.exception.CarNotFoundByFilterException;
+//import com.example._thecore_back.car.exception.CarNotFoundByFilterException;
 import com.example._thecore_back.car.exception.CarNotFoundException;
 import com.example._thecore_back.car.infrastructure.mapper.CarMapper;
 import org.springframework.stereotype.Service;
@@ -61,10 +61,6 @@ public class CarService {
                                               String brand,    CarStatus status) {
 
         var result = carMapper.search(carNumber, model, brand, status);
-
-        if (result.isEmpty()) {
-            throw new CarNotFoundByFilterException();
-        }
 
         return result.stream()
                 .map(CarSearchDto::EntityToDto)

--- a/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
+++ b/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
@@ -45,10 +45,7 @@ public class CarService {
 
     public CarSummaryDto getCountByStatus(){
 
-        Map<CarStatus, Long> result = carReader.getCountByStatus().stream().collect(Collectors.toMap(
-                row -> (CarStatus) row[0],
-                row -> (Long) row[1]
-        ));
+        Map<CarStatus, Long> result = carReader.getCountByStatus();
 
         return CarSummaryDto.builder()
                 .operating(result.getOrDefault(CarStatus.IN_USE, 0L))

--- a/back/src/main/java/com/example/_thecore_back/car/domain/CarReader.java
+++ b/back/src/main/java/com/example/_thecore_back/car/domain/CarReader.java
@@ -2,6 +2,7 @@ package com.example._thecore_back.car.domain;
 
 import javax.swing.plaf.OptionPaneUI;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface CarReader  {
@@ -9,7 +10,7 @@ public interface CarReader  {
 
     List<CarEntity> findAll();
 
-    List<Object[]> getCountByStatus();
+    Map<CarStatus, Long> getCountByStatus();
 
     Optional<CarEntity> findByEmulatorId(Integer emulatorId);
 }

--- a/back/src/main/java/com/example/_thecore_back/car/exception/CarExceptionHandler.java
+++ b/back/src/main/java/com/example/_thecore_back/car/exception/CarExceptionHandler.java
@@ -52,20 +52,4 @@ public class CarExceptionHandler {
                 .status(HttpStatus.NOT_FOUND.value())
                 .body(ApiResponse.fail(response));
     }
-
-    // 필터링 결과가 존재하지 않을때
-
-    @ExceptionHandler(CarNotFoundByFilterException.class)
-    public ApiResponse<CarExceptionResponse> handleCarNotFoundByFilterException(CarNotFoundByFilterException e, HttpServletRequest request) {
-
-        var response = CarExceptionResponse.builder()
-                .timestamp(LocalDateTime.now())
-                .status(HttpStatus.BAD_REQUEST.value())
-                .error(HttpStatus.BAD_REQUEST.getReasonPhrase())
-                .message(e.getMessage())
-                .path(request.getRequestURI())
-                .build();
-
-        return ApiResponse.fail(response);
-    }
 }

--- a/back/src/main/java/com/example/_thecore_back/car/exception/CarNotFoundByFilterException.java
+++ b/back/src/main/java/com/example/_thecore_back/car/exception/CarNotFoundByFilterException.java
@@ -1,7 +1,0 @@
-package com.example._thecore_back.car.exception;
-
-public class CarNotFoundByFilterException extends RuntimeException {
-    public CarNotFoundByFilterException() {
-        super("해당 조건으로 검색된 차가 존재하지 않습니다.");
-    }
-}

--- a/back/src/main/java/com/example/_thecore_back/car/infrastructure/CarReaderImpl.java
+++ b/back/src/main/java/com/example/_thecore_back/car/infrastructure/CarReaderImpl.java
@@ -2,10 +2,13 @@ package com.example._thecore_back.car.infrastructure;
 
 import com.example._thecore_back.car.domain.CarEntity;
 import com.example._thecore_back.car.domain.CarReader;
+import com.example._thecore_back.car.domain.CarStatus;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 public class CarReaderImpl implements CarReader {
@@ -24,8 +27,15 @@ public class CarReaderImpl implements CarReader {
         return carRepository.findAll();
     }
 
-    public List<Object[]> getCountByStatus(){
-        return carRepository.getCountByStatus();
+    public Map<CarStatus, Long> getCountByStatus(){
+
+        List<Object[]> result = carRepository.getCountByStatus();
+
+        return result.stream().collect(Collectors.toMap(
+                row -> (CarStatus) row[0],
+                row -> (Long) row[1]
+        ));
+
     }
 
     public Optional<CarEntity> findByEmulatorId(Integer emulatorId){

--- a/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
+++ b/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
@@ -6,7 +6,6 @@ import com.example._thecore_back.car.controller.dto.*;
 import com.example._thecore_back.car.domain.CarStatus;
 import com.example._thecore_back.car.exception.CarAlreadyExistsException;
 import com.example._thecore_back.car.exception.CarErrorCode;
-import com.example._thecore_back.car.exception.CarNotFoundByFilterException;
 import com.example._thecore_back.car.exception.CarNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +18,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -386,11 +387,12 @@ public class CarControllerTest {
     @Test
     @DisplayName("해당 조건을 충족하는 차량이 없는경우")
     public void getCarsByFilterFailed() throws Exception {
-        when(carService.getCarsByFilter(null, "삼성", null, null)).thenThrow(new CarNotFoundByFilterException());
+        when(carService.getCarsByFilter(null, "삼성", null, null)).thenReturn(Collections.emptyList()
+        );
 
         mockMvc.perform(get("/api/cars/search").param("model", "삼성"))
                 .andDo(print())
-                .andExpect(jsonPath("$.data.status").value(400))
-                .andExpect(jsonPath("$.data.message").value("해당 조건으로 검색된 차가 존재하지 않습니다."));
+                .andExpect(jsonPath("$.result").value(true))
+                .andExpect(jsonPath("$.data.length()").value(0));
     }
 }


### PR DESCRIPTION
# CarService의 getCountByStatus 로직을 CarReaderImpl로 수정

- Service에서 변경하는 것이 아닌 CarReader의 구현체에서 변경

# getCarsByFilter에서 조건에 해당되는 차량이 없으면 예외처리가 아닌 빈리스트 리턴

-  CarNotFoundExceptionByFilter 삭제 (사유: 예외처리를 할 이유가 없어졌으므로)
-  CarExceptionHandler에서도 해당 예외처리 삭제 ( 사유 : 위와 동일)
-  CarControllerTest에서 차량 필터링 조회 실패시 예외처리 대신 빈 리스트로 테스트 진행 및 완료 

Referenced issue : #33 