### PR TITLE
[#35] Refactor: Emulator DB 네이밍 오류 수정 및 컨밴션 적용

### DIFF
--- a/back/src/main/java/com/example/_thecore_back/emulator/application/EmulatorService.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/application/EmulatorService.java
@@ -25,21 +25,22 @@ public class EmulatorService {
     // 애뮬레이터 등록
     public EmulatorEntity registerEmulator(EmulatorRequest emulatorRequest) {
         // 예외처리 1. 차량 존재 여부 확인
-        CarEntity carEntity = carRepository.findByCarNumber(emulatorRequest.getCarNumber())
-                .orElseThrow(() -> new CarNotFoundException("해당하는 차량이 존재하지 않습니다: " + emulatorRequest.getCarNumber()));
+        // TODO: car_number -> device_id 임시 변경. 추후 car테이블 머지 후 수정 필요
+        CarEntity carEntity = carRepository.findByCarNumber(emulatorRequest.getDeviceId())
+                .orElseThrow(() -> new CarNotFoundException("해당하는 차량이 존재하지 않습니다: " + emulatorRequest.getDeviceId()));
 
         // 예외처리 2. 차량에 이미 애뮬레이터가 연결되어 있는지 확인
         if (carEntity.getEmulatorId() != null) {
-            throw new DuplicateEmulatorException("해당 차량에 이미 애뮬레이터가 연결되어 있습니다: " + emulatorRequest.getCarNumber());
+            throw new DuplicateEmulatorException("해당 차량에 이미 애뮬레이터가 연결되어 있습니다: " + emulatorRequest.getDeviceId());
         }
 
         // 예외처리 3. 애뮬레이터 중복 등록 방지 (carNumber 기준)
-        emulatorRepository.findByCarNumber(emulatorRequest.getCarNumber()).ifPresent(emulator -> {
-            throw new DuplicateEmulatorException("이미 등록된 애뮬레이터입니다: " + emulatorRequest.getCarNumber());
+        emulatorRepository.findByDeviceId(emulatorRequest.getDeviceId()).ifPresent(emulator -> {
+            throw new DuplicateEmulatorException("이미 등록된 애뮬레이터입니다: " + emulatorRequest.getDeviceId());
         });
 
         EmulatorEntity entity = EmulatorEntity.builder()
-                .carNumber(emulatorRequest.getCarNumber())  // 차량 번호
+                .carNumber(emulatorRequest.getDeviceId())  // 차량 번호
                 .status(EmulatorStatus.OFF)  // 상태 설정 (초기값: OFF)
                 .build();
 
@@ -68,29 +69,30 @@ public class EmulatorService {
     }
 
     // 애뮬레이터 수정
+    // TODO: car_number -> device_id 임시 변경. 추후 car테이블 머지 후 수정 필요
     public EmulatorEntity updateEmulator(Long id, EmulatorRequest emulatorRequest) {
         // 예외처리 1. 애뮬레이터 존재 여부 확인
         EmulatorEntity entity = emulatorRepository.findById(id)
                 .orElseThrow(() -> new EmulatorNotFoundException("해당하는 애뮬레이터가 없습니다.: " + id));
 
         // 차량 번호가 변경되는 경우에만 예외처리 및 애뮬레이터 업데이트 수행
-        if (!entity.getCarNumber().equals(emulatorRequest.getCarNumber())) {
+        if (!entity.getDeviceId().equals(emulatorRequest.getDeviceId())) {
             // 예외처리 2. 차량 존재 여부 확인
-            CarEntity newCarEntity = carRepository.findByCarNumber(emulatorRequest.getCarNumber())
-                    .orElseThrow(() -> new CarNotFoundException("해당하는 차량이 존재하지 않습니다: " + emulatorRequest.getCarNumber()));
+            CarEntity newCarEntity = carRepository.findByCarNumber(emulatorRequest.getDeviceId())
+                    .orElseThrow(() -> new CarNotFoundException("해당하는 차량이 존재하지 않습니다: " + emulatorRequest.getDeviceId()));
 
             // 예외처리 3. 차량에 이미 애뮬레이터가 연결되어 있는지 확인
             if (newCarEntity.getEmulatorId() != null) {
-                throw new DuplicateEmulatorException("해당 차량에 이미 애뮬레이터가 연결되어 있습니다: " + emulatorRequest.getCarNumber());
+                throw new DuplicateEmulatorException("해당 차량에 이미 애뮬레이터가 연결되어 있습니다: " + emulatorRequest.getDeviceId());
             }
 
             // 예외처리 4. carNumber에 애뮬레이터가 이미 존재하는지 확인 (중복 등록 방지)
-            emulatorRepository.findByCarNumber(emulatorRequest.getCarNumber()).ifPresent(emulator -> {
-                throw new DuplicateEmulatorException("이미 등록된 애뮬레이터입니다: " + emulatorRequest.getCarNumber());
+            emulatorRepository.findByDeviceId(emulatorRequest.getDeviceId()).ifPresent(emulator -> {
+                throw new DuplicateEmulatorException("이미 등록된 애뮬레이터입니다: " + emulatorRequest.getDeviceId());
             });
 
             // 이전 차량의 emulatorId 초기화
-            carRepository.findByCarNumber(entity.getCarNumber()).ifPresent(oldCar -> {
+            carRepository.findByCarNumber(entity.getDeviceId()).ifPresent(oldCar -> {
                 oldCar.setEmulatorId(null);
                 carRepository.save(oldCar);
             });
@@ -100,7 +102,7 @@ public class EmulatorService {
             carRepository.save(newCarEntity);
         }
 
-        entity.setCarNumber(emulatorRequest.getCarNumber());
+        entity.setCarNumber(emulatorRequest.getDeviceId());
 
         return emulatorRepository.save(entity);
     }
@@ -112,7 +114,7 @@ public class EmulatorService {
                 .orElseThrow(() -> new EmulatorNotFoundException("해당하는 애뮬레이터가 없습니다: " + id));
 
         // 연결된 차량의 emulatorId 초기화
-        carRepository.findByCarNumber(emulatorEntity.getCarNumber()).ifPresent(carEntity -> {
+        carRepository.findByCarNumber(emulatorEntity.getDeviceId()).ifPresent(carEntity -> {
             carEntity.setEmulatorId(null);
             carRepository.save(carEntity);
         });

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorRequest.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorRequest.java
@@ -9,5 +9,6 @@ import lombok.Setter;
 public class EmulatorRequest {
 
     @NotNull(message = "차량 번호는 필수입니다.")
-    private String carNumber;
+    // TODO: car_number -> device_id 임시 변경. 추후 car테이블 머지 후 수정 필요
+    private String deviceId;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/domain/EmulatorEntity.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/domain/EmulatorEntity.java
@@ -10,20 +10,26 @@ import lombok.*;
 @Builder
 @ToString
 @Entity
+@Table(name = "emulator")
 public class EmulatorEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String carNumber;   // 차량 번호
+    @Column(name = "device_id", nullable = false, length = 20)
+    private String deviceId; // 디바이스 ID
 
     @Enumerated(EnumType.STRING)
-    private EmulatorStatus status;      // 애뮬레이터 상태
+    @Column(name = "status", nullable = false)
+    private EmulatorStatus status; // 애뮬레이터 상태 (ON/OFF)
+
+    @Transient
+    private String carNumber;
 
     @Builder
-    public EmulatorEntity(String carNumber, EmulatorStatus status) {
-        this.carNumber = carNumber;
+    public EmulatorEntity(String deviceId, EmulatorStatus status) {
+        this.deviceId = deviceId;
         this.status = status;
     }
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/infrastructure/EmulatorRepository.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/infrastructure/EmulatorRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface EmulatorRepository extends JpaRepository<EmulatorEntity, Long> {
-    Optional<EmulatorEntity> findByCarNumber(String carNumber);
+    // TODO: car_number -> device_id 임시 변경. 추후 car테이블 머지 후 수정 필요
+    Optional<EmulatorEntity> findByDeviceId(String deviceId);
 }


### PR DESCRIPTION
## 작업 요약
EmulatorEntity와 DB 컬럼명이 달라서 생기던 missing column 오류를 해결하고, 전체적으로 네이밍 컨벤션을 맞췄습니다.
- 이슈 번호: #35 

## 주요 변경 내용
1. EmulatorEntity와 DB 스키마 동기화
- `@Table(name = "emulator")`, `@Column(name = "device_id")`를 명시하여 DB 컬럼과 매핑
- 이로 인해 DB와 직접 연결되는 필드가 기존 carNumber에서 deviceId로 변경됨

2. car 브랜치 통합 전까지 임시 조치
- `@Transient` 필드 추가: 기존 코드(Service, Controller 등)의 영향을 최소화하기 위해, carNumber 필드는 DB와 무관한 임시 변수로 남겨둠 (getCarNumber() 호출부 유지를 위함)
- 조회 메서드 임시 변경: DB의 device_id 기준으로 데이터를 조회할 수 있도록 EmulatorRepository의 메서드를 findByDeviceId로 수정
  - findByDeviceId 메서드는 car 브랜치가 머지되기 전까지 기존 findByCarNumber를 대신해서 임시로 사용
 
## 앞으로 할 일
- car 머지된 후 아래 임시 코드를 정리할 예정
  - `@Transient` 처리한 carNumber 제거
  - CarEntity랑 연관관계 설정 (`@ManyToOne`)
  - findByDeviceId → 원래대로 바꾸거나 새 구조에 맞게 수정