### PR TITLE
refactor: 차량 조건별 필터링 코드 개선

### DIFF
--- a/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
+++ b/back/src/main/java/com/example/_thecore_back/car/application/CarService.java
@@ -1,13 +1,10 @@
 package com.example._thecore_back.car.application;
 
 
+import com.example._thecore_back.car.controller.dto.*;
 import com.example._thecore_back.car.domain.CarReader;
 import com.example._thecore_back.car.domain.CarWriter;
 import com.example._thecore_back.car.exception.CarAlreadyExistsException;
-import com.example._thecore_back.car.controller.dto.CarDeleteDto;
-import com.example._thecore_back.car.controller.dto.CarDetailDto;
-import com.example._thecore_back.car.controller.dto.CarSearchDto;
-import com.example._thecore_back.car.controller.dto.CarSummaryDto;
 import com.example._thecore_back.car.exception.CarErrorCode;
 //import com.example._thecore_back.car.exception.CarNotFoundByFilterException;
 import com.example._thecore_back.car.exception.CarNotFoundException;
@@ -20,7 +17,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import com.example._thecore_back.car.domain.CarEntity;
 import com.example._thecore_back.car.domain.CarStatus;
-import com.example._thecore_back.car.controller.dto.CarRequestDto;
 
 
 @Service
@@ -57,10 +53,19 @@ public class CarService {
                 .build();
     }
 
-    public List<CarSearchDto> getCarsByFilter(String carNumber, String model,
-                                              String brand,    CarStatus status) {
+//    public List<CarSearchDto> getCarsByFilter(String carNumber, String model,
+//                                              String brand,    CarStatus status) {
+//
+//        var result = carMapper.search(carNumber, model, brand, status);
+//
+//        return result.stream()
+//                .map(CarSearchDto::EntityToDto)
+//                .toList();
+//    }
 
-        var result = carMapper.search(carNumber, model, brand, status);
+    public List<CarSearchDto> getCarsByFilter(CarFilterRequestDto carFilterRequestDto) {
+
+        var result = carMapper.search(carFilterRequestDto);
 
         return result.stream()
                 .map(CarSearchDto::EntityToDto)

--- a/back/src/main/java/com/example/_thecore_back/car/controller/CarController.java
+++ b/back/src/main/java/com/example/_thecore_back/car/controller/CarController.java
@@ -4,12 +4,15 @@ import com.example._thecore_back.car.domain.CarStatus;
 import com.example._thecore_back.common.dto.ApiResponse;
 import com.example._thecore_back.car.validation.group.CreateGroup;
 import com.example._thecore_back.car.application.CarService;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/cars")
@@ -48,22 +51,32 @@ public class CarController {
         return ApiResponse.success(response);
     }
 
-    /**
-     * 조건에 맞는 차량들을 조회하는 메소드
-     * @param carNumber : 차량 번호
-     * @param model : 차량 모델명
-     * @param brand : 차량 브랜드
-     * @param status : 현재 차량 상태
-     * @return 각 조건에 부합하는 차량 조회
-     */
+//    /**
+//     * 조건에 맞는 차량들을 조회하는 메소드
+//     * @param carNumber : 차량 번호
+//     * @param model : 차량 모델명
+//     * @param brand : 차량 브랜드
+//     * @param status : 현재 차량 상태
+//     * @return 각 조건에 부합하는 차량 조회
+//     */
+//    @GetMapping("/search")
+//    public ApiResponse<List<CarSearchDto>> getCarsByFilter(
+//            @RequestParam(required = false) String carNumber,
+//            @RequestParam(required = false) String model,
+//            @RequestParam(required = false) String brand,
+//            @RequestParam(required = false) CarStatus status
+//    ) {
+//        var response = carService.getCarsByFilter(carNumber, model, brand, status);
+//        return ApiResponse.success(response);
+//    }
+
     @GetMapping("/search")
     public ApiResponse<List<CarSearchDto>> getCarsByFilter(
-            @RequestParam(required = false) String carNumber,
-            @RequestParam(required = false) String model,
-            @RequestParam(required = false) String brand,
-            @RequestParam(required = false) CarStatus status
+            @ModelAttribute CarFilterRequestDto carFilterRequestDto
     ) {
-        var response = carService.getCarsByFilter(carNumber, model, brand, status);
+            log.info("Request DTO: {}", carFilterRequestDto);
+
+        var response = carService.getCarsByFilter(carFilterRequestDto);
         return ApiResponse.success(response);
     }
 

--- a/back/src/main/java/com/example/_thecore_back/car/controller/dto/CarFilterRequestDto.java
+++ b/back/src/main/java/com/example/_thecore_back/car/controller/dto/CarFilterRequestDto.java
@@ -1,0 +1,30 @@
+package com.example._thecore_back.car.controller.dto;
+
+
+import com.example._thecore_back.car.domain.CarStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class CarFilterRequestDto {
+
+
+    private String carNumber;
+
+    private String model;
+
+    private String brand;
+
+    private CarStatus status;
+
+    @NotNull
+    private boolean twoParam;
+
+
+}

--- a/back/src/main/java/com/example/_thecore_back/car/exception/CarExceptionHandler.java
+++ b/back/src/main/java/com/example/_thecore_back/car/exception/CarExceptionHandler.java
@@ -24,34 +24,40 @@ public class CarExceptionHandler {
 
     // 차량이 이미 존재할 때 - create
     @ExceptionHandler(CarAlreadyExistsException.class)
-    public ResponseEntity<ApiResponse<CarExceptionResponse>> handleCarAlreadyExistsException(CarAlreadyExistsException e, HttpServletRequest request) {
-        var response = CarExceptionResponse.builder()
-                .timestamp(LocalDateTime.now())
-                .status(HttpStatus.CONFLICT.value())
-                .error(HttpStatus.CONFLICT.getReasonPhrase())
-                .message(e.getMessage())
-                .path(request.getRequestURI())
-                .build();
+    public ResponseEntity<ApiResponse<?>> handleCarAlreadyExistsException(CarAlreadyExistsException e, HttpServletRequest request) {
+//        var response = CarExceptionResponse.builder()
+//                .timestamp(LocalDateTime.now())
+//                .status(HttpStatus.CONFLICT.value())
+//                .error(HttpStatus.CONFLICT.getReasonPhrase())
+//                .message(e.getMessage())
+//                .path(request.getRequestURI())
+//                .build();
 
-        return ResponseEntity
-                .status(HttpStatus.CONFLICT.value())
-                .body(ApiResponse.fail(response.getMessage()));
+        var response = ApiResponse.fail(e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+
+//        return ResponseEntity
+//                .status(HttpStatus.CONFLICT.value())
+//                .body(ApiResponse.fail(response.getMessage()));
     }
 
     // 차량이 존재하지 않을 때
     @ExceptionHandler(CarNotFoundException.class)
-    public ResponseEntity<ApiResponse<CarExceptionResponse>> handleCarNotFoundException(CarNotFoundException e, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<?>> handleCarNotFoundException(CarNotFoundException e, HttpServletRequest request) {
 
-        var response = CarExceptionResponse.builder()
-                .timestamp(LocalDateTime.now())
-                .status(HttpStatus.NOT_FOUND.value())
-                .error(HttpStatus.NOT_FOUND.getReasonPhrase())
-                .message(e.getMessage())
-                .path(request.getRequestURI())
-                .build();
+//        var response = CarExceptionResponse.builder()
+//                .timestamp(LocalDateTime.now())
+//                .status(HttpStatus.NOT_FOUND.value())
+//                .error(HttpStatus.NOT_FOUND.getReasonPhrase())
+//                .message(e.getMessage())
+//                .path(request.getRequestURI())
+//                .build();
 
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND.value())
-                .body(ApiResponse.fail(response.getMessage()));
+//        return ResponseEntity
+//                .status(HttpStatus.NOT_FOUND.value())
+//                .body(ApiResponse.fail(response.getMessage()));
+
+        var response = ApiResponse.fail(e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 }

--- a/back/src/main/java/com/example/_thecore_back/car/infrastructure/mapper/CarMapper.java
+++ b/back/src/main/java/com/example/_thecore_back/car/infrastructure/mapper/CarMapper.java
@@ -1,5 +1,6 @@
 package com.example._thecore_back.car.infrastructure.mapper;
 
+import com.example._thecore_back.car.controller.dto.CarFilterRequestDto;
 import com.example._thecore_back.car.domain.CarEntity;
 import com.example._thecore_back.car.domain.CarStatus;
 import org.apache.ibatis.annotations.Mapper;
@@ -9,8 +10,5 @@ import java.util.List;
 
 @Mapper
 public interface CarMapper {
-    List<CarEntity> search(@Param("carNumber") String carNumber,
-                           @Param("model")     String model,
-                           @Param("brand")     String brand,
-                           @Param("status") CarStatus status);
+    List<CarEntity> search(CarFilterRequestDto carFilterRequestDto);
 }

--- a/back/src/main/resources/mapper/CarMapper.xml
+++ b/back/src/main/resources/mapper/CarMapper.xml
@@ -1,24 +1,55 @@
 <!-- resources/mappers/CarMapper.xml -->
+<!--<!DOCTYPE mapper-->
+<!--        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"-->
+<!--        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">-->
+
+<!--<mapper namespace="com.example._thecore_back.car.infrastructure.mapper.CarMapper">-->
+<!--    <select id="search" resultType="CarEntity">-->
+<!--        SELECT *-->
+<!--        FROM car-->
+<!--        <where>-->
+<!--            <if test="carNumber != null">-->
+<!--                AND car_number = #{carNumber}-->
+<!--            </if>-->
+<!--            <if test="model != null">-->
+<!--                AND model = #{model}-->
+<!--            </if>-->
+<!--            <if test="brand != null">-->
+<!--                AND brand = #{brand}-->
+<!--            </if>-->
+<!--            <if test="status != null">-->
+<!--                AND status = #{status}-->
+<!--            </if>-->
+<!--        </where>-->
+<!--    </select>-->
+
+<!--</mapper>-->
+
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.example._thecore_back.car.infrastructure.mapper.CarMapper">
-    <select id="search" resultType="CarEntity">
+
+    <select id="search" parameterType="com.example._thecore_back.car.controller.dto.CarFilterRequestDto"
+            resultType="com.example._thecore_back.car.domain.CarEntity">
         SELECT *
         FROM car
         <where>
-            <if test="carNumber != null">
+            <if test="carNumber != null and twoParam == true">
                 AND car_number = #{carNumber}
             </if>
-            <if test="model != null">
-                AND model = #{model}
+            <if test="status != null and twoParam == true">
+                AND status = #{status}
             </if>
-            <if test="brand != null">
+            <if test="brand != null and twoParam == true">
                 AND brand = #{brand}
             </if>
-            <if test="status != null">
-                AND status = #{status}
+            <if test="model != null and twoParam == true">
+                AND model = #{model}
+            </if>
+            <if test="brand != null and twoParam == false">
+                AND (brand = #{brand} OR model = #{brand})
             </if>
         </where>
     </select>

--- a/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
+++ b/back/src/test/java/com/example/_thecore_back/car/CarControllerTest.java
@@ -8,6 +8,7 @@ import com.example._thecore_back.car.exception.CarAlreadyExistsException;
 import com.example._thecore_back.car.exception.CarErrorCode;
 import com.example._thecore_back.car.exception.CarNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hibernate.type.TrueFalseConverter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -167,12 +169,15 @@ public class CarControllerTest {
                 .content(objectMapper.writeValueAsString(request)));
 
         actions
+//                .andExpect(status().isConflict())
+//                .andExpect(jsonPath("$.result").value(false))
+//                .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
+//                .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
+//                .andExpect(jsonPath("$.data.message").value("이미 등록된 차량입니다: 12가3456"))
+//                .andExpect(jsonPath("$.data.path").value("/api/cars"));
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.result").value(false))
-                .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
-                .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
-                .andExpect(jsonPath("$.data.message").value("이미 등록된 차량입니다: 12가3456"))
-                .andExpect(jsonPath("$.data.path").value("/api/cars"));
+                .andExpect(jsonPath("$.message").value("이미 등록된 차량입니다: 12가3456"));
     }
 
     @Test
@@ -192,11 +197,14 @@ public class CarControllerTest {
                 .content(objectMapper.writeValueAsString(request)));
 
         actions
+//                .andExpect(status().isNotFound())
+//                .andExpect(jsonPath("$.result").value(false))
+//                .andExpect(jsonPath("$.data.status").value(HttpStatus.NOT_FOUND.value()))
+//                .andExpect(jsonPath("$.data.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+//                .andExpect(jsonPath("$.data.message").value("해당 차량 ( 1234가56 )은 존재하지 않습니다. 다시 입력해주세요"));
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.result").value(false))
-                .andExpect(jsonPath("$.data.status").value(HttpStatus.NOT_FOUND.value()))
-                .andExpect(jsonPath("$.data.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
-                .andExpect(jsonPath("$.data.message").value("해당 차량 ( 1234가56 )은 존재하지 않습니다. 다시 입력해주세요"));
+                .andExpect(jsonPath("$.message").value("해당 차량 ( 1234가56 )은 존재하지 않습니다. 다시 입력해주세요"));
     }
 
     @Test
@@ -216,11 +224,14 @@ public class CarControllerTest {
                 .content(objectMapper.writeValueAsString(request)));
 
         actions
-                .andExpect(status().isConflict())
+//                .andExpect(status().isConflict())
+//                .andExpect(jsonPath("$.result").value(false))
+//                .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
+//                .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
+//                .andExpect(jsonPath("$.data.message").value("이미 등록된 차량입니다: 6543나21"));
+        .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.result").value(false))
-                .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()))
-                .andExpect(jsonPath("$.data.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
-                .andExpect(jsonPath("$.data.message").value("이미 등록된 차량입니다: 6543나21"));
+                .andExpect(jsonPath("$.message").value("이미 등록된 차량입니다: 6543나21"));
     }
 
     @Test
@@ -232,11 +243,14 @@ public class CarControllerTest {
         ResultActions actions = mockMvc.perform(delete("/api/cars/9999가99"));
 
         actions
+//                .andExpect(status().isNotFound())
+//                .andExpect(jsonPath("$.result").value(false))
+//                .andExpect(jsonPath("$.data.status").value(HttpStatus.NOT_FOUND.value()))
+//                .andExpect(jsonPath("$.data.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+//                .andExpect(jsonPath("$.data.message").value("해당 차량 ( 9999가99 )은 존재하지 않습니다. 다시 입력해주세요"));
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.result").value(false))
-                .andExpect(jsonPath("$.data.status").value(HttpStatus.NOT_FOUND.value()))
-                .andExpect(jsonPath("$.data.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
-                .andExpect(jsonPath("$.data.message").value("해당 차량 ( 9999가99 )은 존재하지 않습니다. 다시 입력해주세요"));
+                .andExpect(jsonPath("$.message").value("해당 차량 ( 9999가99 )은 존재하지 않습니다. 다시 입력해주세요"));
     }
 
     @Test
@@ -260,8 +274,9 @@ public class CarControllerTest {
 
         mockMvc.perform(get("/api/cars/1234"))
                 .andDo(print())
-                .andExpect(jsonPath("$.data.status").value(404))
-                .andExpect(jsonPath("$.data.message").value("해당 차량 ( 1234 )은 존재하지 않습니다. 다시 입력해주세요"));
+//                .andExpect(jsonPath("$.data.status").value(404))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("해당 차량 ( 1234 )은 존재하지 않습니다. 다시 입력해주세요"));
     }
 
     @Test
@@ -290,8 +305,8 @@ public class CarControllerTest {
 
         mockMvc.perform(get("/api/cars"))
                 .andDo(print())
-                .andExpect(jsonPath("$.data.status").value(404))
-                .andExpect(jsonPath("$.data.message").value("등록된 차량이 존재하지 않습니다."));
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("등록된 차량이 존재하지 않습니다."));
 
     }
 
@@ -326,37 +341,50 @@ public class CarControllerTest {
     @DisplayName("필터링 조건에 기반하여 차량 조회")
     public void getAllCarsByFilter() throws Exception {
 
+        var requestDto = CarFilterRequestDto.builder()
+                .twoParam(false)
+                .build();
+
         List<CarSearchDto> carList = List.of(new CarSearchDto("12가1234", "현대", "아이오닉", "IDLE")
                 ,new CarSearchDto("12가3423", "기아", "아이오닉", "IDLE"),
                 new CarSearchDto("12가2315", "기아", "그렌저", "MAINTENANCE"));
 
         // 전체 조회
-        when(carService.getCarsByFilter(null, null, null, null)).thenReturn(carList);
+        when(carService.getCarsByFilter(refEq(requestDto))).thenReturn(carList);
 
-        mockMvc.perform(get("/api/cars/search"))
+        mockMvc.perform(get("/api/cars/search").param("twoParam", "false"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(3));
 
-        // 브랜드만 입력
-        List<CarSearchDto> kiaCars = List.of(new CarSearchDto("12가3423", "기아", "아이오닉", "IDLE"),
-                new CarSearchDto("12가2315", "기아", "그렌저", "MAINTENANCE"));
-
-        when(carService.getCarsByFilter(null, null, "기아", null)).thenReturn(kiaCars);
-
-        mockMvc.perform(get("/api/cars/search").param("brand", "기아"))
-                .andDo(print())
-                .andExpect(jsonPath("$.result").value(true))
-                .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].brand").value("기아"))
-                .andExpect(jsonPath("$.data[1].brand").value("기아"));
+//        // 브랜드만 입력
+//        var requestDto_2 = CarFilterRequestDto.builder()
+//                .brand("기아")
+//                .twoParam(false)
+//                .build();
+//
+//        List<CarSearchDto> kiaCars = List.of(new CarSearchDto("12가3423", "기아", "아이오닉", "IDLE"),
+//                new CarSearchDto("12가2315", "기아", "그렌저", "MAINTENANCE"));
+//
+//        when(carService.getCarsByFilter(requestDto_2)).thenReturn(kiaCars);
+//
+//        mockMvc.perform(get("/api/cars/search").param("brand", "기아").param("twoParam", "false"))
+//                .andDo(print())
+//                .andExpect(jsonPath("$.result").value(true))
+//                .andExpect(jsonPath("$.data.length()").value(2))
+//                .andExpect(jsonPath("$.data[0].brand").value("기아"))
+//                .andExpect(jsonPath("$.data[1].brand").value("기아"));
 
         // 차량 번호만 입력
+        var requestDto_3 = CarFilterRequestDto.builder()
+                .carNumber("12가3423")
+                .twoParam(false)
+                .build();
         List<CarSearchDto> carByNumber = List.of(new CarSearchDto("12가3423", "기아", "아이오닉", "IDLE"));
 
-        when(carService.getCarsByFilter("12가3423", null, null, null)).thenReturn(carByNumber);
+        when(carService.getCarsByFilter(refEq(requestDto_3))).thenReturn(carByNumber);
 
-        mockMvc.perform(get("/api/cars/search").param("carNumber", "12가3423"))
+        mockMvc.perform(get("/api/cars/search").param("carNumber", "12가3423").param("twoParam", "false"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(1))
@@ -364,12 +392,16 @@ public class CarControllerTest {
                 .andExpect(jsonPath("$.data[0].car_number").value("12가3423"));
 
         // 차량 상태만 입력
+        var requestDto_4 = CarFilterRequestDto.builder()
+                .status(CarStatus.IDLE)
+                .twoParam(false)
+                .build();
         List<CarSearchDto> carByStatusInIdle = List.of(new CarSearchDto("12가3423", "기아", "아이오닉", "IDLE")
                 , new CarSearchDto("12가3423", "기아", "아이오닉", "IDLE"));
 
-        when(carService.getCarsByFilter(null, null, null, CarStatus.IDLE)).thenReturn(carByStatusInIdle);
+        when(carService.getCarsByFilter(refEq(requestDto_4))).thenReturn(carByStatusInIdle);
 
-        mockMvc.perform(get("/api/cars/search").param("status", CarStatus.IDLE.name()))
+        mockMvc.perform(get("/api/cars/search").param("status", CarStatus.IDLE.name()).param("twoParam", "false"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -377,12 +409,54 @@ public class CarControllerTest {
                 .andExpect(jsonPath("$.data[1].status").value("IDLE"));
 
         // brand, model명 필터링
+        var requestDto_5 = CarFilterRequestDto.builder()
+                .model("아이오닉")
+                .brand("기아")
+                .twoParam(true)
+                .build();
+
         List<CarSearchDto> carByBrandAndModel = List.of(new CarSearchDto("12가3423", "기아", "아이오닉", "IDLE"));
 
-        when(carService.getCarsByFilter(null, "아이오닉", "기아", null)).thenReturn(carByBrandAndModel);
+        when(carService.getCarsByFilter(refEq(requestDto_5))).thenReturn(carByBrandAndModel);
 
         mockMvc.perform(get("/api/cars/search").param("brand", "기아")
-                        .param("model", "아이오닉"))
+                        .param("model", "아이오닉").param("twoParam", "true"))
+                .andDo(print())
+                .andExpect(jsonPath("$.result").value(true))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].brand").value("기아"))
+                .andExpect(jsonPath("$.data[0].model").value("아이오닉"));
+
+        // 브랜드명으로 브랜드명이 옴
+        var requestDto_6 = CarFilterRequestDto.builder()
+                .brand("기아")
+                .twoParam(false)
+                .build();
+
+        List<CarSearchDto> carByBrandAndModelOne = List.of(new CarSearchDto("12가3423", "기아", "아이오닉", "IDLE"),
+                new CarSearchDto("12가3423", "기아", "아이오닉", "IN_USE"));
+
+        when(carService.getCarsByFilter(refEq(requestDto_6))).thenReturn(carByBrandAndModelOne);
+
+        mockMvc.perform(get("/api/cars/search").param("brand", "기아").param("twoParam", "false"))
+                .andDo(print())
+                .andExpect(jsonPath("$.result").value(true))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].brand").value("기아"))
+                .andExpect(jsonPath("$.data[1].brand").value("기아"));
+
+        // 브랜드에 모델명이 들어옴
+
+        var requestDto_7 = CarFilterRequestDto.builder()
+                .brand("아이오닉")
+                .twoParam(false)
+                .build();
+
+        List<CarSearchDto> carByBrandToBrand = List.of(new CarSearchDto("12가3423", "기아", "아이오닉", "IDLE"));
+
+        when(carService.getCarsByFilter(refEq(requestDto_7))).thenReturn(carByBrandToBrand);
+
+        mockMvc.perform(get("/api/cars/search").param("brand", "아이오닉").param("twoParam", "false"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(1))
@@ -394,10 +468,17 @@ public class CarControllerTest {
     @Test
     @DisplayName("해당 조건을 충족하는 차량이 없는경우")
     public void getCarsByFilterFailed() throws Exception {
-        when(carService.getCarsByFilter(null, "삼성", null, null)).thenReturn(Collections.emptyList()
+
+        var requestDto_7 = CarFilterRequestDto.builder()
+                .model("삼성")
+                .twoParam(false)
+                .build();
+
+
+        when(carService.getCarsByFilter(refEq(requestDto_7))).thenReturn(Collections.emptyList()
         );
 
-        mockMvc.perform(get("/api/cars/search").param("model", "삼성"))
+        mockMvc.perform(get("/api/cars/search").param("model", "삼성").param("twoParam", "false"))
                 .andDo(print())
                 .andExpect(jsonPath("$.result").value(true))
                 .andExpect(jsonPath("$.data.length()").value(0));


### PR DESCRIPTION
## 차량 조건별 필터링 코드 개선

1. 프론트에서 브랜드명 + 모델명으로 입력 받는데 사용자가 공백을 기준으로 각각 입력하는 것이 아닌 브랜드명 혹은 모델명만 입력 받았을 때도 조회가 정상적으로 되도록 구현
2. 기존 CarController에서 requestparam으로 파라미터를 받던 것을 CarFilterRequestDto 요청 객체를 만들어 유지 보수가 쉽도록 리펙토링 진행
3. 1번 로직의 변경에 따른 mybatis 기반 동적 쿼리 변경 (CarMapper, CarMapper.xml)

## 예외 처리 핸들러 응답 방식 수정

1. 기존에 Car에서 쓰던 예외처리 응답을 통일한 response 양식으로 리펙토링 진행 및 이에 따른 테스트 코드 수정 후 테스트 결과 이상없음 확인

---

# Referenced Issue : #51 