### PR TITLE
[#50] feat: EmulatorEntity 리팩토링 및 deviceId 기반 식별자로 변경

### DIFF
--- a/back/src/main/java/com/example/_thecore_back/emulator/application/EmulatorService.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/application/EmulatorService.java
@@ -44,13 +44,13 @@ public class EmulatorService {
 
         EmulatorEntity savedEntity = emulatorRepository.save(entity);
 
-        carEntity.setEmulatorId(savedEntity.getId().intValue());
+        carEntity.setEmulatorId(savedEntity.getId());
         carRepository.save(carEntity);
 
         return savedEntity;
     }
 
-    public EmulatorEntity getEmulator(Long id) {
+    public EmulatorEntity getEmulator(int id) {
         return emulatorRepository.findById(id)
                 .orElseThrow(() -> new EmulatorNotFoundException("해당하는 애뮬레이터가 없습니다: " + id));
     }
@@ -60,7 +60,7 @@ public class EmulatorService {
     }
 
     @Transactional
-    public EmulatorEntity updateEmulator(Long id, EmulatorRequest emulatorRequest) {
+    public EmulatorEntity updateEmulator(int id, EmulatorRequest emulatorRequest) {
         EmulatorEntity entity = emulatorRepository.findById(id)
                 .orElseThrow(() -> new EmulatorNotFoundException("해당하는 애뮬레이터가 없습니다.: " + id));
 
@@ -84,7 +84,7 @@ public class EmulatorService {
                 carRepository.save(oldCar);
             });
 
-            newCarEntity.setEmulatorId(entity.getId().intValue());
+            newCarEntity.setEmulatorId(entity.getId());
             carRepository.save(newCarEntity);
 
             entity.setDeviceId(newDeviceId);
@@ -94,7 +94,7 @@ public class EmulatorService {
     }
 
     @Transactional
-    public void deleteEmulator(Long id) {
+    public void deleteEmulator(int id) {
         EmulatorEntity emulatorEntity = emulatorRepository.findById(id)
                 .orElseThrow(() -> new EmulatorNotFoundException("해당하는 애뮬레이터가 없습니다: " + id));
 

--- a/back/src/main/java/com/example/_thecore_back/emulator/application/EmulatorService.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/application/EmulatorService.java
@@ -51,12 +51,25 @@ public class EmulatorService {
     }
 
     public EmulatorEntity getEmulator(int id) {
-        return emulatorRepository.findById(id)
+        EmulatorEntity emulatorEntity = emulatorRepository.findById(id)
                 .orElseThrow(() -> new EmulatorNotFoundException("해당하는 애뮬레이터가 없습니다: " + id));
+
+        // carRepository를 사용해 carNumber를 찾아와서 Transient 필드에 설정
+        carRepository.findByEmulatorId(emulatorEntity.getId()).ifPresent(carEntity -> {
+            emulatorEntity.setCarNumber(carEntity.getCarNumber());
+        });
+
+        return emulatorEntity;
     }
 
     public List<EmulatorEntity> getAllEmulators() {
-        return emulatorRepository.findAll();
+        List<EmulatorEntity> emulators = emulatorRepository.findAll();
+        emulators.forEach(emulator -> {
+            carRepository.findByCarNumber(emulator.getDeviceId()).ifPresent(carEntity -> {
+                emulator.setCarNumber(carEntity.getCarNumber());
+            });
+        });
+        return emulators;
     }
 
     @Transactional

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/EmulatorController.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/EmulatorController.java
@@ -37,7 +37,7 @@ public class EmulatorController {
     // 애뮬레이터 상세 조회
     @GetMapping("/{emulator_id}")
     public ResponseEntity<ApiResponse<GetEmulatorResponseData>> getEmulator(
-            @PathVariable("emulator_id") Long emulatorId
+            @PathVariable("emulator_id") int emulatorId
     ) {
         EmulatorEntity getEntity = emulatorService.getEmulator(emulatorId);
         GetEmulatorResponseData responseData = emulatorConverter.toGetEmulatorData(getEntity);
@@ -59,7 +59,7 @@ public class EmulatorController {
     // 애뮬레이터 수정
     @PatchMapping("/{emulator_id}")
     public ResponseEntity<ApiResponse<UpdateEmulatorResponseData>> updateEmulator(
-            @PathVariable("emulator_id") Long emulatorId,
+            @PathVariable("emulator_id") int emulatorId,
             @Valid @RequestBody EmulatorRequest emulatorRequest
     ){
         EmulatorEntity updatedEntity = emulatorService.updateEmulator(emulatorId, emulatorRequest);
@@ -71,7 +71,7 @@ public class EmulatorController {
     // 애뮬레이터 삭제
     @DeleteMapping("/{emulator_id}")
     public ResponseEntity<ApiResponse<DeleteEmulatorResponseData>> deleteEmulator(
-            @PathVariable("emulator_id") Long emulatorId
+            @PathVariable("emulator_id") int emulatorId
     ){
         emulatorService.deleteEmulator(emulatorId);
         DeleteEmulatorResponseData responseData = DeleteEmulatorResponseData.builder()

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/EmulatorController.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/EmulatorController.java
@@ -35,11 +35,11 @@ public class EmulatorController {
 
 
     // 애뮬레이터 상세 조회
-    @GetMapping("/{emulator_id}")
+    @GetMapping("/{device_id}")
     public ResponseEntity<ApiResponse<GetEmulatorResponseData>> getEmulator(
-            @PathVariable("emulator_id") int emulatorId
+            @PathVariable("device_id") String deviceId
     ) {
-        EmulatorEntity getEntity = emulatorService.getEmulator(emulatorId);
+        EmulatorEntity getEntity = emulatorService.getEmulator(deviceId);
         GetEmulatorResponseData responseData = emulatorConverter.toGetEmulatorData(getEntity);
 
         return ResponseEntity.ok(ApiResponse.success(null, responseData));
@@ -57,25 +57,25 @@ public class EmulatorController {
     }
 
     // 애뮬레이터 수정
-    @PatchMapping("/{emulator_id}")
+    @PatchMapping("/{device_id}")
     public ResponseEntity<ApiResponse<UpdateEmulatorResponseData>> updateEmulator(
-            @PathVariable("emulator_id") int emulatorId,
+            @PathVariable("device_id") String deviceId,
             @Valid @RequestBody EmulatorRequest emulatorRequest
     ){
-        EmulatorEntity updatedEntity = emulatorService.updateEmulator(emulatorId, emulatorRequest);
+        EmulatorEntity updatedEntity = emulatorService.updateEmulator(deviceId, emulatorRequest);
         UpdateEmulatorResponseData responseData = emulatorConverter.toUpdateEmulatorData(updatedEntity);
 
         return ResponseEntity.ok(ApiResponse.success("애뮬레이터 정보가 수정되었습니다.", responseData));
     }
 
     // 애뮬레이터 삭제
-    @DeleteMapping("/{emulator_id}")
+    @DeleteMapping("/{device_id}")
     public ResponseEntity<ApiResponse<DeleteEmulatorResponseData>> deleteEmulator(
-            @PathVariable("emulator_id") int emulatorId
+            @PathVariable("device_id") String deviceId
     ){
-        emulatorService.deleteEmulator(emulatorId);
+        emulatorService.deleteEmulator(deviceId);
         DeleteEmulatorResponseData responseData = DeleteEmulatorResponseData.builder()
-                .emulatorId(emulatorId)
+                .deviceId(deviceId)
                 .build();
 
         return ResponseEntity.ok(ApiResponse.success("애뮬레이터가 삭제되었습니다.", responseData));

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/DeleteEmulatorResponseData.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/DeleteEmulatorResponseData.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @Builder
 public class DeleteEmulatorResponseData {
-    private int emulatorId;
+    private String deviceId;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/DeleteEmulatorResponseData.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/DeleteEmulatorResponseData.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @Builder
 public class DeleteEmulatorResponseData {
-    private Long emulatorId;
+    private int emulatorId;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorConverter.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorConverter.java
@@ -8,7 +8,7 @@ public class EmulatorConverter {
 
     public EmulatorResponse toResponse(EmulatorEntity emulatorEntity) {
         EmulatorResponse response = new EmulatorResponse();
-        response.setId(emulatorEntity.getId());
+        response.setDeviceId(emulatorEntity.getDeviceId());
         response.setCarNumber(emulatorEntity.getCarNumber());
         response.setStatus(emulatorEntity.getStatus());
         return response;
@@ -16,7 +16,7 @@ public class EmulatorConverter {
 
     public EmulatorEntity toEntity(EmulatorResponse emulatorResponse) {
         EmulatorEntity entity = new EmulatorEntity();
-        entity.setId(emulatorResponse.getId());
+        entity.setDeviceId(emulatorResponse.getDeviceId());
         entity.setCarNumber(emulatorResponse.getCarNumber());
         entity.setStatus(emulatorResponse.getStatus());
         return entity;
@@ -27,7 +27,7 @@ public class EmulatorConverter {
             EmulatorEntity emulatorEntity
     ) {
         return RegisterEmulatorResponseData.builder()
-                .emulatorId(emulatorEntity.getId())
+                .deviceId(emulatorEntity.getDeviceId())
                 .carNumber(emulatorEntity.getCarNumber())
                 .emulatorStatus(emulatorEntity.getStatus())
                 .build()
@@ -39,7 +39,7 @@ public class EmulatorConverter {
             EmulatorEntity emulatorEntity
     ) {
         return GetEmulatorResponseData.builder()
-                .emulatorId(emulatorEntity.getId())
+                .deviceId(emulatorEntity.getDeviceId())
                 .carNumber(emulatorEntity.getCarNumber())
                 .emulatorStatus(emulatorEntity.getStatus())
                 .build()
@@ -51,7 +51,7 @@ public class EmulatorConverter {
             EmulatorEntity emulatorEntity
     ) {
         return UpdateEmulatorResponseData.builder()
-                .emulatorId(emulatorEntity.getId())
+                .deviceId(emulatorEntity.getDeviceId())
                 .carNumber(emulatorEntity.getCarNumber())
                 .build()
                 ;

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorRequest.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorRequest.java
@@ -13,10 +13,5 @@ import lombok.Setter;
 public class EmulatorRequest {
 
     @NotNull(message = "차량 번호는 필수입니다.")
-    // TODO: car_number -> device_id 임시 변경. 추후 car테이블 머지 후 수정 필요
-    private String deviceId;
-
-    // TODO: 임시로 만든 함수
-    public void setCarNumber(String s) {
-    }
+    private String carNumber;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorResponse.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorResponse.java
@@ -7,8 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class EmulatorResponse {
-
-    private Long id;            // 애뮬레이터 id
+    private int id;            // 애뮬레이터 id
     private String carNumber;   // 차량 번호
     private EmulatorStatus status;      // 상태
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorResponse.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/EmulatorResponse.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class EmulatorResponse {
-    private int id;            // 애뮬레이터 id
+    private String deviceId;            // 애뮬레이터 id
     private String carNumber;   // 차량 번호
     private EmulatorStatus status;      // 상태
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/GetEmulatorResponseData.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/GetEmulatorResponseData.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class GetEmulatorResponseData {
-    private Long emulatorId;
+    private int emulatorId;
     private String carNumber;
     private EmulatorStatus emulatorStatus;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/GetEmulatorResponseData.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/GetEmulatorResponseData.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class GetEmulatorResponseData {
-    private int emulatorId;
+    private String deviceId;
     private String carNumber;
     private EmulatorStatus emulatorStatus;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/RegisterEmulatorResponseData.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/RegisterEmulatorResponseData.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class RegisterEmulatorResponseData {
-    private int emulatorId;
+    private String deviceId;
     private String carNumber;
     private EmulatorStatus emulatorStatus;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/RegisterEmulatorResponseData.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/RegisterEmulatorResponseData.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class RegisterEmulatorResponseData {
-    private Long emulatorId;
+    private int emulatorId;
     private String carNumber;
     private EmulatorStatus emulatorStatus;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/UpdateEmulatorResponseData.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/UpdateEmulatorResponseData.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @Builder
 public class UpdateEmulatorResponseData {
-    private Long emulatorId;
+    private int emulatorId;
     private String carNumber;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/UpdateEmulatorResponseData.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/controller/dto/UpdateEmulatorResponseData.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @Builder
 public class UpdateEmulatorResponseData {
-    private int emulatorId;
+    private String deviceId;
     private String carNumber;
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/domain/EmulatorEntity.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/domain/EmulatorEntity.java
@@ -15,7 +15,7 @@ public class EmulatorEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private int id;
 
     @Column(name = "device_id", nullable = false, length = 20)
     private String deviceId; // 디바이스 ID

--- a/back/src/main/java/com/example/_thecore_back/emulator/domain/EmulatorEntity.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/domain/EmulatorEntity.java
@@ -3,6 +3,8 @@ package com.example._thecore_back.emulator.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.UUID;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -17,7 +19,7 @@ public class EmulatorEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @Column(name = "device_id", nullable = false, length = 20)
+    @Column(name = "device_id", nullable = false, length = 36)
     private String deviceId; // 디바이스 ID
 
     @Enumerated(EnumType.STRING)
@@ -27,9 +29,14 @@ public class EmulatorEntity {
     @Transient
     private String carNumber;
 
-    @Builder
-    public EmulatorEntity(String deviceId, EmulatorStatus status) {
-        this.deviceId = deviceId;
+    @PrePersist
+    public void createDeviceId() {
+        if (deviceId == null) {
+            deviceId = UUID.randomUUID().toString();
+        }
+    }
+
+    public EmulatorEntity(EmulatorStatus status) {
         this.status = status;
     }
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/domain/EmulatorReader.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/domain/EmulatorReader.java
@@ -4,6 +4,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface EmulatorReader {
-    Optional<EmulatorEntity> findById(Long id);
+    Optional<EmulatorEntity> findById(int id);
     List<EmulatorEntity> findAll();
 }

--- a/back/src/main/java/com/example/_thecore_back/emulator/infrastructure/EmulatorReaderImpl.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/infrastructure/EmulatorReaderImpl.java
@@ -16,7 +16,7 @@ public class EmulatorReaderImpl implements EmulatorReader {
     }
 
     @Override
-    public Optional<EmulatorEntity> findById(Long id) {
+    public Optional<EmulatorEntity> findById(int id) {
         return emulatorRepository.findById(id);
     }
 

--- a/back/src/main/java/com/example/_thecore_back/emulator/infrastructure/EmulatorRepository.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/infrastructure/EmulatorRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface EmulatorRepository extends JpaRepository<EmulatorEntity, Long> {
+public interface EmulatorRepository extends JpaRepository<EmulatorEntity, Integer> {
     // TODO: car_number -> device_id 임시 변경. 추후 car테이블 머지 후 수정 필요
     Optional<EmulatorEntity> findByDeviceId(String deviceId);
 

--- a/back/src/main/java/com/example/_thecore_back/emulator/infrastructure/EmulatorRepository.java
+++ b/back/src/main/java/com/example/_thecore_back/emulator/infrastructure/EmulatorRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface EmulatorRepository extends JpaRepository<EmulatorEntity, Integer> {
-    // TODO: car_number -> device_id 임시 변경. 추후 car테이블 머지 후 수정 필요
     Optional<EmulatorEntity> findByDeviceId(String deviceId);
-
+    void deleteByDeviceId(String deviceId);
 }

--- a/back/src/test/java/com/example/_thecore_back/emulator/application/EmulatorServiceTest.java
+++ b/back/src/test/java/com/example/_thecore_back/emulator/application/EmulatorServiceTest.java
@@ -46,7 +46,7 @@ public class EmulatorServiceTest {
     @BeforeEach
     void setUp() {
         emulatorRequest = new EmulatorRequest();
-        emulatorRequest.setDeviceId("123가 4567");
+        emulatorRequest.setCarNumber("123가 4567");
 
         carEntity = CarEntity.builder()
                 .id(1)
@@ -55,7 +55,7 @@ public class EmulatorServiceTest {
 
         emulatorEntity = EmulatorEntity.builder()
                 .id(1)
-                .deviceId("123가 4567")
+                .deviceId("a1b2c3d4-test-uuid")
                 .status(EmulatorStatus.OFF)
                 .build();
     }
@@ -65,13 +65,15 @@ public class EmulatorServiceTest {
     void registerEmulator_success() {
         when(carRepository.findByCarNumber(anyString())).thenReturn(Optional.of(carEntity));
         when(emulatorRepository.save(any(EmulatorEntity.class))).thenReturn(emulatorEntity);
+        when(carRepository.save(any(CarEntity.class))).thenReturn(carEntity);
 
         EmulatorEntity result = emulatorService.registerEmulator(emulatorRequest);
 
         assertNotNull(result);
-        assertEquals("123가 4567", result.getDeviceId());
-        assertEquals(EmulatorStatus.OFF, result.getStatus());
+        assertEquals(emulatorEntity.getDeviceId(), result.getDeviceId());
+        assertEquals(emulatorRequest.getCarNumber(), result.getCarNumber());
         verify(carRepository, times(1)).save(any(CarEntity.class));
+        assertEquals(emulatorEntity.getId(), carEntity.getEmulatorId());
     }
 
     @Test
@@ -98,35 +100,49 @@ public class EmulatorServiceTest {
     @Test
     @DisplayName("애뮬레이터 상세 조회 성공")
     void getEmulator_success() {
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
+        String deviceId ="a1b2c3d4-test-uuid";
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.of(emulatorEntity));
+        when(carRepository.findByEmulatorId(emulatorEntity.getId())).thenReturn(Optional.of(carEntity));
 
-        EmulatorEntity result = emulatorService.getEmulator(1);
+        EmulatorEntity result = emulatorService.getEmulator(deviceId);
 
         assertNotNull(result);
-        assertEquals(1, result.getId());
-        assertEquals("123가 4567", result.getDeviceId());
+        assertEquals(deviceId, result.getDeviceId());
+        assertEquals("123가 4567", result.getCarNumber());
     }
 
     @Test
     @DisplayName("애뮬레이터 상세 조회 실패 - 애뮬레이터 없음")
     void getEmulator_notFound() {
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.empty());
+        String deviceId ="a1b2c3d4-test-uuid";
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.empty());
 
-        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.getEmulator(1));
+        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.getEmulator(deviceId));
     }
 
     @Test
     @DisplayName("애뮬레이터 전체 조회 성공")
     void getAllEmulators_success() {
-        List<EmulatorEntity> emulators = Arrays.asList(emulatorEntity, EmulatorEntity.builder().id(2).deviceId("789나 0123").status(EmulatorStatus.ON).build());
+        EmulatorEntity emulator2 = EmulatorEntity.builder().id(2).deviceId("z9y8x7w6-test-uuid").status(EmulatorStatus.ON).build();
+        CarEntity car2 = CarEntity.builder().id(2).carNumber("789나 0123").emulatorId(2).build();
+        List<EmulatorEntity> emulators = Arrays.asList(emulatorEntity, emulator2);
+
         when(emulatorRepository.findAll()).thenReturn(emulators);
+        when(carRepository.findByEmulatorId(emulatorEntity.getId())).thenReturn(Optional.of(carEntity));
+        when(carRepository.findByEmulatorId(emulator2.getId())).thenReturn(Optional.of(car2));
 
         List<EmulatorEntity> result = emulatorService.getAllEmulators();
 
         assertNotNull(result);
         assertEquals(2, result.size());
-        assertEquals("123가 4567", result.get(0).getDeviceId());
-        assertEquals("789나 0123", result.get(1).getDeviceId());
+
+        // 첫 번째 에뮬레이터
+        assertEquals(emulatorEntity.getDeviceId(), result.get(0).getDeviceId());
+        assertEquals(carEntity.getCarNumber(), result.get(0).getCarNumber());
+
+        // 두 번째 에뮬레이터
+        assertEquals(emulator2.getDeviceId(), result.get(1).getDeviceId());
+        assertEquals(car2.getCarNumber(), result.get(1).getCarNumber());
     }
 
     @Test
@@ -143,59 +159,65 @@ public class EmulatorServiceTest {
     @Test
     @DisplayName("애뮬레이터 수정 성공 - 차량 번호 변경 없을 때")
     void updateEmulator_noCarNumberChange_success() {
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
-        when(emulatorRepository.save(any(EmulatorEntity.class))).thenReturn(emulatorEntity);
+        String deviceId = emulatorEntity.getDeviceId();
+        emulatorRequest.setCarNumber("123가 4567");
+        carEntity.setEmulatorId(emulatorEntity.getId());
 
-        EmulatorEntity result = emulatorService.updateEmulator(1, emulatorRequest);
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.of(emulatorEntity));
+        when(carRepository.findByEmulatorId(emulatorEntity.getId())).thenReturn(Optional.of(carEntity));
+        when(carRepository.findByCarNumber("123가 4567")).thenReturn(Optional.of(carEntity));
+        when(carRepository.save(any(CarEntity.class))).thenReturn(carEntity);
+
+        EmulatorEntity result = emulatorService.updateEmulator(deviceId, emulatorRequest);
 
         assertNotNull(result);
-        assertEquals("123가 4567", result.getDeviceId());
-        verify(carRepository, never()).findByCarNumber(anyString());
-        verify(carRepository, never()).save(any(CarEntity.class));
+        assertEquals("123가 4567", result.getCarNumber());
+        verify(carRepository, times(1)).save(any(CarEntity.class));
     }
 
     @Test
     @DisplayName("애뮬레이터 수정 성공 - 차량 번호 변경 있을 때")
     void updateEmulator_carNumberChange_success() {
-        EmulatorRequest updatedRequest = new EmulatorRequest();
-        updatedRequest.setDeviceId("새로운 차량 번호");
+        String deviceId = emulatorEntity.getDeviceId();
+        String newCarNumber = "새로운 차량 번호";
+        EmulatorRequest updatedRequest = new EmulatorRequest(newCarNumber);
 
-        CarEntity oldCarEntity = CarEntity.builder().id(1).carNumber("123가 4567").emulatorId(1).build();
-        CarEntity newCarEntity = CarEntity.builder().id(2).carNumber("새로운 차량 번호").build();
+        CarEntity oldCarEntity = CarEntity.builder().id(1).carNumber("123가 4567").emulatorId(emulatorEntity.getId()).build();
+        CarEntity newCarEntity = CarEntity.builder().id(2).carNumber(newCarNumber).build();
 
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
-        when(carRepository.findByCarNumber("새로운 차량 번호")).thenReturn(Optional.of(newCarEntity));
-        when(carRepository.findByCarNumber("123가 4567")).thenReturn(Optional.of(oldCarEntity));
-        when(emulatorRepository.findByDeviceId("새로운 차량 번호")).thenReturn(Optional.empty());
-        when(emulatorRepository.save(any(EmulatorEntity.class))).thenReturn(emulatorEntity);
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.of(emulatorEntity));
+        when(carRepository.findByEmulatorId(emulatorEntity.getId())).thenReturn(Optional.of(oldCarEntity));
+        when(carRepository.findByCarNumber(newCarNumber)).thenReturn(Optional.of(newCarEntity));
 
-        EmulatorEntity result = emulatorService.updateEmulator(1, updatedRequest);
+        EmulatorEntity result = emulatorService.updateEmulator(deviceId, updatedRequest);
 
         assertNotNull(result);
-        assertEquals("새로운 차량 번호", result.getDeviceId());
+        assertEquals(newCarNumber, result.getCarNumber());
         assertNull(oldCarEntity.getEmulatorId());
-        assertEquals(1, newCarEntity.getEmulatorId());
+        assertEquals(emulatorEntity.getId(), newCarEntity.getEmulatorId());
         verify(carRepository, times(2)).save(any(CarEntity.class));
     }
 
     @Test
     @DisplayName("애뮬레이터 수정 실패 - 애뮬레이터 없음")
     void updateEmulator_emulatorNotFound() {
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.empty());
+        String deviceId = "a1b2c3d4-test-uuid";
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.empty());
 
-        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.updateEmulator(1, emulatorRequest));
+        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.updateEmulator(deviceId, emulatorRequest));
     }
 
     @Test
     @DisplayName("애뮬레이터 수정 실패 - 변경할 차량 없음")
     void updateEmulator_newCarNotFound() {
-        EmulatorRequest updatedRequest = new EmulatorRequest();
-        updatedRequest.setDeviceId("새로운 차량 번호");
+        String deviceId = emulatorEntity.getDeviceId();
+        String newCarNumber = "없는 차량 번호";
+        EmulatorRequest updatedRequest = new EmulatorRequest(newCarNumber);
 
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
-        when(carRepository.findByCarNumber("새로운 차량 번호")).thenReturn(Optional.empty());
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.of(emulatorEntity));
+        when(carRepository.findByCarNumber(newCarNumber)).thenReturn(Optional.empty());
 
-        assertThrows(CarNotFoundException.class, () -> emulatorService.updateEmulator(1, updatedRequest));
+        assertThrows(CarNotFoundException.class, () -> emulatorService.updateEmulator(deviceId, updatedRequest));
         verify(emulatorRepository, never()).save(any(EmulatorEntity.class));
         verify(carRepository, never()).save(any(CarEntity.class));
     }
@@ -203,15 +225,16 @@ public class EmulatorServiceTest {
     @Test
     @DisplayName("애뮬레이터 수정 실패 - 변경할 차량에 이미 애뮬레이터 연결됨")
     void updateEmulator_newCarAlreadyHasEmulator() {
-        EmulatorRequest updatedRequest = new EmulatorRequest();
-        updatedRequest.setDeviceId("새로운 차량 번호");
+        String deviceId = emulatorEntity.getDeviceId();
+        String newCarNumber = "새로운 차량 번호";
+        EmulatorRequest updatedRequest = new EmulatorRequest(newCarNumber);
 
-        CarEntity newCarEntityWithEmulator = CarEntity.builder().id(2).carNumber("새로운 차량 번호").emulatorId(5).build();
+        CarEntity newCarEntityWithEmulator = CarEntity.builder().id(2).carNumber(newCarNumber).emulatorId(5).build();
 
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
-        when(carRepository.findByCarNumber("새로운 차량 번호")).thenReturn(Optional.of(newCarEntityWithEmulator));
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.of(emulatorEntity));
+        when(carRepository.findByCarNumber(newCarNumber)).thenReturn(Optional.of(newCarEntityWithEmulator));
 
-        assertThrows(DuplicateEmulatorException.class, () -> emulatorService.updateEmulator(1, updatedRequest));
+        assertThrows(DuplicateEmulatorException.class, () -> emulatorService.updateEmulator(deviceId, updatedRequest));
         verify(emulatorRepository, never()).save(any(EmulatorEntity.class));
         verify(carRepository, never()).save(any(CarEntity.class));
     }
@@ -219,17 +242,16 @@ public class EmulatorServiceTest {
     @Test
     @DisplayName("애뮬레이터 수정 실패 - 변경할 carNumber에 이미 애뮬레이터 존재")
     void updateEmulator_duplicateEmulatorOnNewCarNumber() {
-        EmulatorRequest updatedRequest = new EmulatorRequest();
-        updatedRequest.setDeviceId("새로운 차량 번호");
+        String deviceId = emulatorEntity.getDeviceId();
+        String newCarNumber = "새로운 차량 번호";
+        EmulatorRequest updatedRequest = new EmulatorRequest(newCarNumber);
 
-        CarEntity newCarEntity = CarEntity.builder().id(2).carNumber("새로운 차량 번호").build();
-        EmulatorEntity existingEmulatorOnNewCar = EmulatorEntity.builder().id(3).deviceId("새로운 차량 번호").build();
+        CarEntity newCarEntity = CarEntity.builder().id(2).carNumber(newCarNumber).emulatorId(99).build(); // 다른 emulatorId
 
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
-        when(carRepository.findByCarNumber("새로운 차량 번호")).thenReturn(Optional.of(newCarEntity));
-        when(emulatorRepository.findByDeviceId("새로운 차량 번호")).thenReturn(Optional.of(existingEmulatorOnNewCar));
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.of(emulatorEntity));
+        when(carRepository.findByCarNumber(newCarNumber)).thenReturn(Optional.of(newCarEntity));
 
-        assertThrows(DuplicateEmulatorException.class, () -> emulatorService.updateEmulator(1, updatedRequest));
+        assertThrows(DuplicateEmulatorException.class, () -> emulatorService.updateEmulator(deviceId, updatedRequest));
         verify(emulatorRepository, never()).save(any(EmulatorEntity.class));
         verify(carRepository, never()).save(any(CarEntity.class));
     }
@@ -237,25 +259,26 @@ public class EmulatorServiceTest {
     @Test
     @DisplayName("애뮬레이터 삭제 성공")
     void deleteEmulator_success() {
-        carEntity.setEmulatorId(1);
+        String deviceId = "a1b2c3d4-test-uuid";
+        carEntity.setEmulatorId(emulatorEntity.getId()); // 이미 연결된 상태로 설정
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.of(emulatorEntity));
+        when(carRepository.findByEmulatorId(emulatorEntity.getId())).thenReturn(Optional.of(carEntity));
 
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
-        when(carRepository.findByCarNumber(anyString())).thenReturn(Optional.of(carEntity));
-
-        emulatorService.deleteEmulator(1);
+        emulatorService.deleteEmulator(deviceId);
 
         assertNull(carEntity.getEmulatorId());
         verify(carRepository, times(1)).save(carEntity);
-        verify(emulatorRepository, times(1)).deleteById(1);
+        verify(emulatorRepository, times(1)).delete(emulatorEntity);
     }
 
     @Test
     @DisplayName("애뮬레이터 삭제 실패 - 애뮬레이터 없음")
     void deleteEmulator_notFound() {
-        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.empty());
+        String deviceId = "존재하지 않는 deviceId";
+        when(emulatorRepository.findByDeviceId(deviceId)).thenReturn(Optional.empty());
 
-        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.deleteEmulator(1));
-        verify(emulatorRepository, never()).deleteById(anyInt());
+        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.deleteEmulator(deviceId));
+        verify(emulatorRepository, never()).delete(any(EmulatorEntity.class));
         verify(carRepository, never()).save(any(CarEntity.class));
     }
 }

--- a/back/src/test/java/com/example/_thecore_back/emulator/application/EmulatorServiceTest.java
+++ b/back/src/test/java/com/example/_thecore_back/emulator/application/EmulatorServiceTest.java
@@ -54,7 +54,7 @@ public class EmulatorServiceTest {
                 .build();
 
         emulatorEntity = EmulatorEntity.builder()
-                .id(1L)
+                .id(1)
                 .deviceId("123가 4567")
                 .status(EmulatorStatus.OFF)
                 .build();
@@ -98,27 +98,27 @@ public class EmulatorServiceTest {
     @Test
     @DisplayName("애뮬레이터 상세 조회 성공")
     void getEmulator_success() {
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.of(emulatorEntity));
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
 
-        EmulatorEntity result = emulatorService.getEmulator(1L);
+        EmulatorEntity result = emulatorService.getEmulator(1);
 
         assertNotNull(result);
-        assertEquals(1L, result.getId());
+        assertEquals(1, result.getId());
         assertEquals("123가 4567", result.getDeviceId());
     }
 
     @Test
     @DisplayName("애뮬레이터 상세 조회 실패 - 애뮬레이터 없음")
     void getEmulator_notFound() {
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.empty());
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.empty());
 
-        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.getEmulator(1L));
+        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.getEmulator(1));
     }
 
     @Test
     @DisplayName("애뮬레이터 전체 조회 성공")
     void getAllEmulators_success() {
-        List<EmulatorEntity> emulators = Arrays.asList(emulatorEntity, EmulatorEntity.builder().id(2L).deviceId("789나 0123").status(EmulatorStatus.ON).build());
+        List<EmulatorEntity> emulators = Arrays.asList(emulatorEntity, EmulatorEntity.builder().id(2).deviceId("789나 0123").status(EmulatorStatus.ON).build());
         when(emulatorRepository.findAll()).thenReturn(emulators);
 
         List<EmulatorEntity> result = emulatorService.getAllEmulators();
@@ -143,10 +143,10 @@ public class EmulatorServiceTest {
     @Test
     @DisplayName("애뮬레이터 수정 성공 - 차량 번호 변경 없을 때")
     void updateEmulator_noCarNumberChange_success() {
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.of(emulatorEntity));
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
         when(emulatorRepository.save(any(EmulatorEntity.class))).thenReturn(emulatorEntity);
 
-        EmulatorEntity result = emulatorService.updateEmulator(1L, emulatorRequest);
+        EmulatorEntity result = emulatorService.updateEmulator(1, emulatorRequest);
 
         assertNotNull(result);
         assertEquals("123가 4567", result.getDeviceId());
@@ -163,13 +163,13 @@ public class EmulatorServiceTest {
         CarEntity oldCarEntity = CarEntity.builder().id(1).carNumber("123가 4567").emulatorId(1).build();
         CarEntity newCarEntity = CarEntity.builder().id(2).carNumber("새로운 차량 번호").build();
 
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.of(emulatorEntity));
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
         when(carRepository.findByCarNumber("새로운 차량 번호")).thenReturn(Optional.of(newCarEntity));
         when(carRepository.findByCarNumber("123가 4567")).thenReturn(Optional.of(oldCarEntity));
         when(emulatorRepository.findByDeviceId("새로운 차량 번호")).thenReturn(Optional.empty());
         when(emulatorRepository.save(any(EmulatorEntity.class))).thenReturn(emulatorEntity);
 
-        EmulatorEntity result = emulatorService.updateEmulator(1L, updatedRequest);
+        EmulatorEntity result = emulatorService.updateEmulator(1, updatedRequest);
 
         assertNotNull(result);
         assertEquals("새로운 차량 번호", result.getDeviceId());
@@ -181,9 +181,9 @@ public class EmulatorServiceTest {
     @Test
     @DisplayName("애뮬레이터 수정 실패 - 애뮬레이터 없음")
     void updateEmulator_emulatorNotFound() {
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.empty());
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.empty());
 
-        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.updateEmulator(1L, emulatorRequest));
+        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.updateEmulator(1, emulatorRequest));
     }
 
     @Test
@@ -192,10 +192,10 @@ public class EmulatorServiceTest {
         EmulatorRequest updatedRequest = new EmulatorRequest();
         updatedRequest.setDeviceId("새로운 차량 번호");
 
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.of(emulatorEntity));
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
         when(carRepository.findByCarNumber("새로운 차량 번호")).thenReturn(Optional.empty());
 
-        assertThrows(CarNotFoundException.class, () -> emulatorService.updateEmulator(1L, updatedRequest));
+        assertThrows(CarNotFoundException.class, () -> emulatorService.updateEmulator(1, updatedRequest));
         verify(emulatorRepository, never()).save(any(EmulatorEntity.class));
         verify(carRepository, never()).save(any(CarEntity.class));
     }
@@ -208,10 +208,10 @@ public class EmulatorServiceTest {
 
         CarEntity newCarEntityWithEmulator = CarEntity.builder().id(2).carNumber("새로운 차량 번호").emulatorId(5).build();
 
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.of(emulatorEntity));
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
         when(carRepository.findByCarNumber("새로운 차량 번호")).thenReturn(Optional.of(newCarEntityWithEmulator));
 
-        assertThrows(DuplicateEmulatorException.class, () -> emulatorService.updateEmulator(1L, updatedRequest));
+        assertThrows(DuplicateEmulatorException.class, () -> emulatorService.updateEmulator(1, updatedRequest));
         verify(emulatorRepository, never()).save(any(EmulatorEntity.class));
         verify(carRepository, never()).save(any(CarEntity.class));
     }
@@ -223,13 +223,13 @@ public class EmulatorServiceTest {
         updatedRequest.setDeviceId("새로운 차량 번호");
 
         CarEntity newCarEntity = CarEntity.builder().id(2).carNumber("새로운 차량 번호").build();
-        EmulatorEntity existingEmulatorOnNewCar = EmulatorEntity.builder().id(3L).deviceId("새로운 차량 번호").build();
+        EmulatorEntity existingEmulatorOnNewCar = EmulatorEntity.builder().id(3).deviceId("새로운 차량 번호").build();
 
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.of(emulatorEntity));
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
         when(carRepository.findByCarNumber("새로운 차량 번호")).thenReturn(Optional.of(newCarEntity));
         when(emulatorRepository.findByDeviceId("새로운 차량 번호")).thenReturn(Optional.of(existingEmulatorOnNewCar));
 
-        assertThrows(DuplicateEmulatorException.class, () -> emulatorService.updateEmulator(1L, updatedRequest));
+        assertThrows(DuplicateEmulatorException.class, () -> emulatorService.updateEmulator(1, updatedRequest));
         verify(emulatorRepository, never()).save(any(EmulatorEntity.class));
         verify(carRepository, never()).save(any(CarEntity.class));
     }
@@ -239,23 +239,23 @@ public class EmulatorServiceTest {
     void deleteEmulator_success() {
         carEntity.setEmulatorId(1);
 
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.of(emulatorEntity));
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.of(emulatorEntity));
         when(carRepository.findByCarNumber(anyString())).thenReturn(Optional.of(carEntity));
 
-        emulatorService.deleteEmulator(1L);
+        emulatorService.deleteEmulator(1);
 
         assertNull(carEntity.getEmulatorId());
         verify(carRepository, times(1)).save(carEntity);
-        verify(emulatorRepository, times(1)).deleteById(1L);
+        verify(emulatorRepository, times(1)).deleteById(1);
     }
 
     @Test
     @DisplayName("애뮬레이터 삭제 실패 - 애뮬레이터 없음")
     void deleteEmulator_notFound() {
-        when(emulatorRepository.findById(anyLong())).thenReturn(Optional.empty());
+        when(emulatorRepository.findById(anyInt())).thenReturn(Optional.empty());
 
-        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.deleteEmulator(1L));
-        verify(emulatorRepository, never()).deleteById(anyLong());
+        assertThrows(EmulatorNotFoundException.class, () -> emulatorService.deleteEmulator(1));
+        verify(emulatorRepository, never()).deleteById(anyInt());
         verify(carRepository, never()).save(any(CarEntity.class));
     }
 }

--- a/back/src/test/java/com/example/_thecore_back/emulator/controller/EmulatorControllerTest.java
+++ b/back/src/test/java/com/example/_thecore_back/emulator/controller/EmulatorControllerTest.java
@@ -50,13 +50,13 @@ public class EmulatorControllerTest {
         emulatorRequest.setCarNumber("123가 4567");
 
         emulatorEntity = EmulatorEntity.builder()
-                .id(1L)
+                .id(1)
                 .carNumber("123가 4567")
                 .status(EmulatorStatus.OFF)
                 .build();
 
         getEmulatorResponseData = GetEmulatorResponseData.builder()
-                .emulatorId(1L)
+                .emulatorId(1)
                 .carNumber("123가 4567")
                 .emulatorStatus(EmulatorStatus.OFF)
                 .build();
@@ -67,7 +67,7 @@ public class EmulatorControllerTest {
     void registerEmulator_success() {
         when(emulatorService.registerEmulator(any(EmulatorRequest.class))).thenReturn(emulatorEntity);
         when(emulatorConverter.toRegisterEmulatorData(any(EmulatorEntity.class)))
-                .thenReturn(new RegisterEmulatorResponseData(1L, "123가4567", EmulatorStatus.OFF));
+                .thenReturn(new RegisterEmulatorResponseData(1, "123가4567", EmulatorStatus.OFF));
 
         ResponseEntity<ApiResponse<RegisterEmulatorResponseData>> response = emulatorController.registerEmulator(emulatorRequest);
 
@@ -99,23 +99,23 @@ public class EmulatorControllerTest {
     @Test
     @DisplayName("애뮬레이터 상세 조회 성공")
     void getEmulator_success() {
-        when(emulatorService.getEmulator(anyLong())).thenReturn(emulatorEntity);
+        when(emulatorService.getEmulator(anyInt())).thenReturn(emulatorEntity);
         when(emulatorConverter.toGetEmulatorData(any(EmulatorEntity.class))).thenReturn(getEmulatorResponseData);
 
-        ResponseEntity<ApiResponse<GetEmulatorResponseData>> response = emulatorController.getEmulator(1L);
+        ResponseEntity<ApiResponse<GetEmulatorResponseData>> response = emulatorController.getEmulator(1);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(1L, response.getBody().getData().getEmulatorId());
-        verify(emulatorService).getEmulator(1L);
+        assertEquals(1, response.getBody().getData().getEmulatorId());
+        verify(emulatorService).getEmulator(1);
     }
 
     @Test
     @DisplayName("애뮬레이터 상세 조회 실패 - 애뮬레이터 없음")
     void getEmulator_notFound() {
-        when(emulatorService.getEmulator(anyLong())).thenThrow(new EmulatorNotFoundException("Not Found"));
+        when(emulatorService.getEmulator(anyInt())).thenThrow(new EmulatorNotFoundException("Not Found"));
 
-        assertThrows(EmulatorNotFoundException.class, () -> emulatorController.getEmulator(1L));
-        verify(emulatorService).getEmulator(1L);
+        assertThrows(EmulatorNotFoundException.class, () -> emulatorController.getEmulator(1));
+        verify(emulatorService).getEmulator(1);
     }
 
     @Test
@@ -148,15 +148,15 @@ public class EmulatorControllerTest {
     @Test
     @DisplayName("애뮬레이터 수정 성공 - 차량 번호 변경 없을 때")
     void updateEmulator_noCarNumberChange_success() {
-        when(emulatorService.updateEmulator(anyLong(), any())).thenReturn(emulatorEntity);
+        when(emulatorService.updateEmulator(anyInt(), any())).thenReturn(emulatorEntity);
         when(emulatorConverter.toUpdateEmulatorData(any()))
-                .thenReturn(UpdateEmulatorResponseData.builder().emulatorId(1L).carNumber("123가4567").build());
+                .thenReturn(UpdateEmulatorResponseData.builder().emulatorId(1).carNumber("123가4567").build());
 
-        ResponseEntity<ApiResponse<UpdateEmulatorResponseData>> response = emulatorController.updateEmulator(1L, emulatorRequest);
+        ResponseEntity<ApiResponse<UpdateEmulatorResponseData>> response = emulatorController.updateEmulator(1, emulatorRequest);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("애뮬레이터 정보가 수정되었습니다.", response.getBody().getMessage());
-        verify(emulatorService).updateEmulator(1L, emulatorRequest);
+        verify(emulatorService).updateEmulator(1, emulatorRequest);
     }
 
     @Test
@@ -165,15 +165,15 @@ public class EmulatorControllerTest {
         EmulatorRequest newRequest = new EmulatorRequest();
         newRequest.setCarNumber("789다 9999");
 
-        when(emulatorService.updateEmulator(eq(1L), any())).thenReturn(emulatorEntity);
+        when(emulatorService.updateEmulator(eq(1), any())).thenReturn(emulatorEntity);
         when(emulatorConverter.toUpdateEmulatorData(any()))
-                .thenReturn(UpdateEmulatorResponseData.builder().emulatorId(1L).carNumber("789다 9999").build());
+                .thenReturn(UpdateEmulatorResponseData.builder().emulatorId(1).carNumber("789다 9999").build());
 
-        ResponseEntity<ApiResponse<UpdateEmulatorResponseData>> response = emulatorController.updateEmulator(1L, newRequest);
+        ResponseEntity<ApiResponse<UpdateEmulatorResponseData>> response = emulatorController.updateEmulator(1, newRequest);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("애뮬레이터 정보가 수정되었습니다.", response.getBody().getMessage());
-        verify(emulatorService).updateEmulator(1L, newRequest);
+        verify(emulatorService).updateEmulator(1, newRequest);
     }
 
     // X
@@ -181,59 +181,59 @@ public class EmulatorControllerTest {
     @DisplayName("애뮬레이터 수정 성공")
     void updateEmulator_success() {
         // given
-        when(emulatorService.updateEmulator(anyLong(), any(EmulatorRequest.class))).thenReturn(emulatorEntity);
+        when(emulatorService.updateEmulator(anyInt(), any(EmulatorRequest.class))).thenReturn(emulatorEntity);
         when(emulatorConverter.toUpdateEmulatorData(any(EmulatorEntity.class)))
-                .thenReturn(UpdateEmulatorResponseData.builder().emulatorId(1L).carNumber("123가4567").build());
+                .thenReturn(UpdateEmulatorResponseData.builder().emulatorId(1).carNumber("123가4567").build());
 
         // when
-        ResponseEntity<ApiResponse<UpdateEmulatorResponseData>> response = emulatorController.updateEmulator(1L, emulatorRequest);
+        ResponseEntity<ApiResponse<UpdateEmulatorResponseData>> response = emulatorController.updateEmulator(1, emulatorRequest);
 
         // then
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("애뮬레이터 정보가 수정되었습니다.", response.getBody().getMessage());
-        verify(emulatorService).updateEmulator(1L, emulatorRequest);
+        verify(emulatorService).updateEmulator(1, emulatorRequest);
     }
 
     @Test
     @DisplayName("애뮬레이터 수정 실패 - 애뮬레이터 없음")
     void updateEmulator_emulatorNotFound() {
-        when(emulatorService.updateEmulator(anyLong(), any())).thenThrow(new EmulatorNotFoundException("not found"));
+        when(emulatorService.updateEmulator(anyInt(), any())).thenThrow(new EmulatorNotFoundException("not found"));
 
         assertThrows(EmulatorNotFoundException.class, () ->
-                emulatorController.updateEmulator(1L, emulatorRequest));
-        verify(emulatorService).updateEmulator(1L, emulatorRequest);
+                emulatorController.updateEmulator(1, emulatorRequest));
+        verify(emulatorService).updateEmulator(1, emulatorRequest);
     }
 
     @Test
     @DisplayName("애뮬레이터 수정 실패 - 변경할 차량 없음")
     void updateEmulator_newCarNotFound() {
-        when(emulatorService.updateEmulator(anyLong(), any())).thenThrow(new CarNotFoundException("no car"));
+        when(emulatorService.updateEmulator(anyInt(), any())).thenThrow(new CarNotFoundException("no car"));
 
         assertThrows(CarNotFoundException.class, () ->
-                emulatorController.updateEmulator(1L, emulatorRequest));
-        verify(emulatorService).updateEmulator(1L, emulatorRequest);
+                emulatorController.updateEmulator(1, emulatorRequest));
+        verify(emulatorService).updateEmulator(1, emulatorRequest);
     }
 
     @Test
     @DisplayName("애뮬레이터 삭제 성공")
     void deleteEmulator_success() {
-        doNothing().when(emulatorService).deleteEmulator(anyLong());
+        doNothing().when(emulatorService).deleteEmulator(anyInt());
 
-        ResponseEntity<ApiResponse<DeleteEmulatorResponseData>> response = emulatorController.deleteEmulator(1L);
+        ResponseEntity<ApiResponse<DeleteEmulatorResponseData>> response = emulatorController.deleteEmulator(1);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("애뮬레이터가 삭제되었습니다.", response.getBody().getMessage());
-        verify(emulatorService).deleteEmulator(1L);
+        verify(emulatorService).deleteEmulator(1);
     }
 
     @Test
     @DisplayName("애뮬레이터 삭제 실패 - 애뮬레이터 없음")
     void deleteEmulator_notFound() {
-        doThrow(new EmulatorNotFoundException("not found")).when(emulatorService).deleteEmulator(1L);
+        doThrow(new EmulatorNotFoundException("not found")).when(emulatorService).deleteEmulator(1);
 
         assertThrows(EmulatorNotFoundException.class, () ->
-                emulatorController.deleteEmulator(1L));
-        verify(emulatorService).deleteEmulator(1L);
+                emulatorController.deleteEmulator(1));
+        verify(emulatorService).deleteEmulator(1);
     }
 
 }


### PR DESCRIPTION
## 작업 요약
기존 EmulatorEntity에서 id 기반 식별 로직을 UUID 기반 deviceId로 전환하고, 관련 로직 및 테스트 코드를 함께 수정했습니다.
- 이슈 번호: #50 

## 주요 변경 내용
- Emulator의 PK 타입을 Long -> int로 수정
- carNumber를 `@Transient` 필드로 변경하고, 서비스에서 값을 채워주도록 수정
- Emulator 등록 시, deviceId를 랜덤 UUID로 자동 생성하도록 로직 추가
- API 식별자를 id 대신 deviceId를 사용하도록 수정
- 변경사항 반영해 테스트 코드 수정