### PR TITLE
feat: 차량 조회 pagination 구현 및 테스트코드 수정

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+	implementation 'mysql:mysql-connector-java:8.0.33'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mockito:mockito-core'

--- a/back/src/main/java/com/example/_thecore_back/admin/application/AdminService.java
+++ b/back/src/main/java/com/example/_thecore_back/admin/application/AdminService.java
@@ -36,6 +36,7 @@ public class AdminService {
                 .phoneNumber(requestDto.getPhoneNumber())
                 .email(requestDto.getEmail())
                 .birthdate(requestDto.getBirthdate())
+                .authLevel("ADMIN") // 기본 권한 부여
                 .build();
 
         AdminEntity savedEntity = adminRepository.save(adminEntity);

--- a/back/src/main/java/com/example/_thecore_back/admin/domain/AdminEntity.java
+++ b/back/src/main/java/com/example/_thecore_back/admin/domain/AdminEntity.java
@@ -38,4 +38,9 @@ public class AdminEntity {
 
     @Column(nullable = false)
     private LocalDate birthdate;
+
+    @Column(nullable = false)
+    private String authLevel;
+
+
 }

--- a/back/src/main/java/com/example/_thecore_back/car/controller/CarController.java
+++ b/back/src/main/java/com/example/_thecore_back/car/controller/CarController.java
@@ -6,6 +6,9 @@ import com.example._thecore_back.car.validation.group.CreateGroup;
 import com.example._thecore_back.car.application.CarService;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
@@ -37,9 +40,13 @@ public class CarController {
     }
 
     @GetMapping
-    public ApiResponse<List<CarSearchDto>> getAllCars() {
+    public ApiResponse<Page<CarSearchDto>> getAllCars(@RequestParam(defaultValue = "1") int page,
+                                                      @RequestParam(defaultValue = "10") int size)
+    {
 
-        var response = carService.getAllCars();
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        var response = carService.getAllCars(pageable);
 
         return ApiResponse.success(response);
     }
@@ -71,12 +78,14 @@ public class CarController {
 //    }
 
     @GetMapping("/search")
-    public ApiResponse<List<CarSearchDto>> getCarsByFilter(
-            @ModelAttribute CarFilterRequestDto carFilterRequestDto
+    public ApiResponse<Page<CarSearchDto>> getCarsByFilter(
+            @ModelAttribute CarFilterRequestDto carFilterRequestDto,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int offset
     ) {
             log.info("Request DTO: {}", carFilterRequestDto);
 
-        var response = carService.getCarsByFilter(carFilterRequestDto);
+        var response = carService.getCarsByFilter(carFilterRequestDto, page, offset);
         return ApiResponse.success(response);
     }
 

--- a/back/src/main/java/com/example/_thecore_back/car/domain/CarReader.java
+++ b/back/src/main/java/com/example/_thecore_back/car/domain/CarReader.java
@@ -1,5 +1,8 @@
 package com.example._thecore_back.car.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import javax.swing.plaf.OptionPaneUI;
 import java.util.List;
 import java.util.Map;
@@ -8,7 +11,7 @@ import java.util.Optional;
 public interface CarReader  {
     Optional<CarEntity> findByCarNumber(String carNumber);
 
-    List<CarEntity> findAll();
+    Page<CarEntity> findAll(Pageable pageable);
 
     Map<CarStatus, Long> getCountByStatus();
 

--- a/back/src/main/java/com/example/_thecore_back/car/infrastructure/CarReaderImpl.java
+++ b/back/src/main/java/com/example/_thecore_back/car/infrastructure/CarReaderImpl.java
@@ -3,6 +3,8 @@ package com.example._thecore_back.car.infrastructure;
 import com.example._thecore_back.car.domain.CarEntity;
 import com.example._thecore_back.car.domain.CarReader;
 import com.example._thecore_back.car.domain.CarStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,8 +25,12 @@ public class CarReaderImpl implements CarReader {
         return carRepository.findByCarNumber(carNumber);
     }
 
-    public List<CarEntity> findAll(){
-        return carRepository.findAll();
+//    public List<CarEntity> findAll(){
+//        return carRepository.findAll();
+//    }
+
+    public Page<CarEntity> findAll(Pageable pageable){
+        return carRepository.findAll(pageable);
     }
 
     public Map<CarStatus, Long> getCountByStatus(){

--- a/back/src/main/java/com/example/_thecore_back/car/infrastructure/mapper/CarMapper.java
+++ b/back/src/main/java/com/example/_thecore_back/car/infrastructure/mapper/CarMapper.java
@@ -10,5 +10,10 @@ import java.util.List;
 
 @Mapper
 public interface CarMapper {
-    List<CarEntity> search(CarFilterRequestDto carFilterRequestDto);
+    List<CarEntity> search(@Param("filter") CarFilterRequestDto carFilterRequestDto,
+                           @Param("offset") int offset,
+                           @Param("limit") int limit);
+
+    int countByFilter(@Param("filter") CarFilterRequestDto carFilterRequestDto);
+
 }

--- a/back/src/main/resources/mapper/CarMapper.xml
+++ b/back/src/main/resources/mapper/CarMapper.xml
@@ -31,25 +31,51 @@
 
 <mapper namespace="com.example._thecore_back.car.infrastructure.mapper.CarMapper">
 
-    <select id="search" parameterType="com.example._thecore_back.car.controller.dto.CarFilterRequestDto"
+    <select id="search" parameterType="map"
             resultType="com.example._thecore_back.car.domain.CarEntity">
         SELECT *
         FROM car
         <where>
-            <if test="carNumber != null and twoParam == true">
-                AND car_number = #{carNumber}
+            <if test="filter.carNumber != null and filter.twoParam == true">
+                AND car_number = #{filter.carNumber}
             </if>
-            <if test="status != null and twoParam == true">
-                AND status = #{status}
+            <if test="filter.status != null and filter.twoParam == true">
+                AND status = #{filter.status}
             </if>
-            <if test="brand != null and twoParam == true">
-                AND brand = #{brand}
+            <if test="filter.brand != null and filter.twoParam == true">
+                AND brand = #{filter.brand}
             </if>
-            <if test="model != null and twoParam == true">
-                AND model = #{model}
+            <if test="filter.model != null and filter.twoParam == true">
+                AND model = #{filter.model}
             </if>
-            <if test="brand != null and twoParam == false">
-                AND (brand = #{brand} OR model = #{brand})
+            <if test="filter.brand != null and filter.twoParam == false">
+                AND (brand = #{filter.brand} OR model = #{filter.brand})
+            </if>
+        </where>
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countByFilter"
+            parameterType="map"
+            resultType="int">
+
+        SELECT COUNT(*)
+        FROM car
+        <where>
+            <if test="filter.carNumber != null and filter.twoParam == true">
+                AND car_number = #{filter.carNumber}
+            </if>
+            <if test="filter.status != null and filter.twoParam == true">
+                AND status = #{filter.status}
+            </if>
+            <if test="filter.brand != null and filter.twoParam == true">
+                AND brand = #{filter.brand}
+            </if>
+            <if test="filter.model != null and filter.twoParam == true">
+                AND model = #{filter.model}
+            </if>
+            <if test="filter.brand != null and filter.twoParam == false">
+                AND (brand = #{filter.brand} OR model = #{filter.brand})
             </if>
         </where>
     </select>

--- a/back/src/test/java/com/example/_thecore_back/car/infrastructure/CarRederImplTest.java
+++ b/back/src/test/java/com/example/_thecore_back/car/infrastructure/CarRederImplTest.java
@@ -1,5 +1,6 @@
 package com.example._thecore_back.car.infrastructure;
 
+import com.example._thecore_back.car.controller.dto.CarSearchDto;
 import com.example._thecore_back.car.domain.CarEntity;
 import com.example._thecore_back.car.domain.CarStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,6 +9,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
@@ -52,11 +57,17 @@ public class CarRederImplTest {
     @DisplayName("등록되어 있는 전체 차량 조회")
     public void getAllCars(){
         List<CarEntity> carEntities = List.of(new CarEntity(),  new CarEntity());
-        when(carRepository.findAll()).thenReturn(carEntities);
 
-        List<CarEntity> result = carReader.findAll();
+        Page<CarEntity> pageResult = new PageImpl<>(carEntities);
 
-        assertEquals(2, result.size());
+        Pageable pageable = PageRequest.of(0, 4);
+
+        when(carRepository.findAll(pageable)).thenReturn(pageResult);
+
+        Page<CarEntity> result = carReader.findAll(pageable);
+
+        assertEquals(2, result.getContent().size());
+        assertEquals(1, result.getTotalPages());
     }
 
     @Test


### PR DESCRIPTION
1. 차량 조회 즉 리스트를 리턴해야 하는 경우 페이지네이션을 적용하였습니다. 또한 그에 따라 testcode도 추가하였습니다.
2. Admin Entity, request 승진님께서 올려주신 방법을 적용시켰습니다.
3. CarStatus에 status를 넣어도 default로 적용되는 문제는 carService의 차량 등록 메소드로 따로 로직을 추가하여 해결하였습니다.

---

# Referenced issue : #56 