### PR TITLE
[#63] Feat: 에뮬레이터 전체 조회 API 페이지네이션 추가

### DIFF
--- a/back/emulator-server/src/main/java/com/example/emulatorserver/device/application/EmulatorService.java
+++ b/back/emulator-server/src/main/java/com/example/emulatorserver/device/application/EmulatorService.java
@@ -11,6 +11,8 @@ import com.example.emulatorserver.device.exception.emulator.EmulatorNotFoundExce
 import com.example.emulatorserver.device.exception.emulator.DuplicateEmulatorException;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,14 +62,14 @@ public class EmulatorService {
         return emulatorEntity;
     }
 
-    public List<EmulatorEntity> getAllEmulators() {
-        List<EmulatorEntity> emulators = emulatorRepository.findAll();
-        emulators.forEach(emulator -> {
+    public Page<EmulatorEntity> getAllEmulators(Pageable pageable) {
+        Page<EmulatorEntity> emulatorsPage = emulatorRepository.findAll(pageable);
+        emulatorsPage.getContent().forEach(emulator -> {
             carRepository.findByEmulatorId(emulator.getId()).ifPresent(car -> {
                 emulator.setCarNumber(car.getCarNumber());
             });
         });
-        return emulators;
+        return emulatorsPage;
     }
 
     @Transactional

--- a/back/emulator-server/src/main/java/com/example/emulatorserver/device/application/LogService.java
+++ b/back/emulator-server/src/main/java/com/example/emulatorserver/device/application/LogService.java
@@ -24,7 +24,7 @@ public class LogService {
         CarEntity carEntity = carReader.findByCarNumber(carNumber)
                 .orElseThrow(() -> new CarNotFoundException(CarErrorCode.CAR_NOT_FOUND_BY_NUMBER, carNumber));
 
-        EmulatorEntity emulatorEntity = emulatorReader.getById(carEntity.getEmulatorId().longValue());
+        EmulatorEntity emulatorEntity = emulatorReader.getById(carEntity.getEmulatorId());
 
         emulatorEntity.setStatus(EmulatorStatus.getEmulatorStatus(powerStatus));
 

--- a/back/emulator-server/src/main/java/com/example/emulatorserver/device/controller/EmulatorController.java
+++ b/back/emulator-server/src/main/java/com/example/emulatorserver/device/controller/EmulatorController.java
@@ -7,6 +7,10 @@ import com.example.emulatorserver.device.application.EmulatorService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -47,13 +51,13 @@ public class EmulatorController {
 
     // 애뮬레이터 전체 조회
     @GetMapping
-    public ResponseEntity<ApiResponse<List<GetEmulatorResponseData>>> getAllEmulators() {
-        List<EmulatorEntity>  getEntities = emulatorService.getAllEmulators();
-        List<GetEmulatorResponseData> responseDataList = getEntities.stream()
-                .map(emulatorConverter::toGetEmulatorData)
-                .collect(Collectors.toList());
+    public ResponseEntity<ApiResponse<CustomPageResponse<GetEmulatorResponseData>>> getAllEmulators(
+            @PageableDefault(size=10, sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<EmulatorEntity> emulatorsPage = emulatorService.getAllEmulators(pageable);
+        Page<GetEmulatorResponseData> dtoPage = emulatorsPage.map(emulatorConverter::toGetEmulatorData);
+        CustomPageResponse<GetEmulatorResponseData> responseData = new CustomPageResponse<>(dtoPage);
 
-        return ResponseEntity.ok(ApiResponse.success(null, responseDataList));
+        return ResponseEntity.ok(ApiResponse.success(null, responseData));
     }
 
     // 애뮬레이터 수정

--- a/back/emulator-server/src/main/java/com/example/emulatorserver/device/controller/dto/CustomPageResponse.java
+++ b/back/emulator-server/src/main/java/com/example/emulatorserver/device/controller/dto/CustomPageResponse.java
@@ -1,0 +1,22 @@
+package com.example.emulatorserver.device.controller.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class CustomPageResponse<T> {
+
+    private final List<T> content;
+    private final int totalPages;
+    private final long totalElements;
+    private final boolean last;
+
+    public CustomPageResponse(Page<T> page){
+        this.content = page.getContent();
+        this.totalPages = page.getTotalPages();
+        this.totalElements = page.getTotalElements();
+        this.last = page.isLast();
+    }
+}

--- a/back/emulator-server/src/main/java/com/example/emulatorserver/device/domain/emulator/EmulatorReader.java
+++ b/back/emulator-server/src/main/java/com/example/emulatorserver/device/domain/emulator/EmulatorReader.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 public interface EmulatorReader {
     Optional<EmulatorEntity> findById(int id);
     List<EmulatorEntity> findAll();
-    EmulatorEntity getById(Long id);
+    EmulatorEntity getById(int id);
 }

--- a/back/emulator-server/src/main/java/com/example/emulatorserver/device/infrastructure/emulator/EmulatorReaderImpl.java
+++ b/back/emulator-server/src/main/java/com/example/emulatorserver/device/infrastructure/emulator/EmulatorReaderImpl.java
@@ -28,7 +28,7 @@ public class EmulatorReaderImpl implements EmulatorReader {
     @Override
     // 확실하게 해당 아이디를 가진 애뮬레이터가 존재할 경우, 애뮬레이터를 조회하는 용도
     // 불필요하게 중복된 예외 처리를 하지 않기 위함
-    public EmulatorEntity getById(Long id) {
+    public EmulatorEntity getById(int id) {
         return emulatorRepository.findById(id).orElse(null);
     }
 }

--- a/back/emulator-server/src/test/java/com/example/emulatorserver/emulator/application/LogServiceTest.java
+++ b/back/emulator-server/src/test/java/com/example/emulatorserver/emulator/application/LogServiceTest.java
@@ -52,7 +52,7 @@ class LogServiceTest {
                 .build();
 
         when(carReader.findByCarNumber("12가3456")).thenReturn(Optional.of(car));
-        when(emulatorReader.getById(1L)).thenReturn(emulator);
+        when(emulatorReader.getById(1)).thenReturn(emulator);
 
         // when
         LogPowerDto result = logService.changePowerStatus(input);
@@ -100,7 +100,7 @@ class LogServiceTest {
                 .build();
 
         when(carReader.findByCarNumber("12가3456")).thenReturn(Optional.of(car));
-        when(emulatorReader.getById(1L)).thenReturn(emulator);
+        when(emulatorReader.getById(1)).thenReturn(emulator);
 
         // when & then
         assertThrows(IllegalArgumentException.class, () -> {


### PR DESCRIPTION
## 수정 내용
- 페이지네이션 구현
- 응답 DTO(CustomPageResponse) 추가로 필요한 항목만 응답에 포함되도록 구현
- 관련된 테스트 코드 수정
- 에뮬레이터 전체 조회 API 명세서 수정
- (추가) EmulatorReader의 getById 메소드 파라미터 타입을 Long에서 int로 변경


## 관련 이슈
- #63