### PR TITLE
[#69] Chore: 에뮬레이터 서버에 AWS RDS 연동 설정

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -63,3 +63,4 @@ gradle-app.setting
 /src/main/resources/application.yaml
 /src/main/resources/application.properties
 /src/test/resources/application-test.yml
+emulator-server/src/main/resources/application.yml

--- a/back/emulator-server/build.gradle
+++ b/back/emulator-server/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     // DB
-    implementation 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/back/emulator-server/src/main/resources/application.properties
+++ b/back/emulator-server/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-server.port=8081


### PR DESCRIPTION
## 수정 내용
- application.properties -> application.yml로 이름 변환 후 보안상 깃 추적 제외(.gitignore에 추가)
- application.yml에 AWS RDS 접속 정보 설정
- build.gradle에 MySQL 드라이버 의존성 추가

## 기타
- 보안 이슈로 인해 설정 파일(application.yml)은 깃허브에 포함하지 않았습니다.
- 설정 파일은 디스코드에 공유하겠습니다. 머지 후 해당 파일을 받아 프로젝트에 적용해주세요.

## 관련 이슈
- #69 