### PR TITLE
[#78] Chore: emulator-server 인증 제거 관련 설정 수정

### DIFF
--- a/back/emulator-server/build.gradle
+++ b/back/emulator-server/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Swagger(OpenAPI)
@@ -47,7 +46,6 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mockito:mockito-core'
-    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 


### PR DESCRIPTION
emulator-server는 인증 없이 API가 동작해야 하므로  
build.gradle에서 spring security 관련 의존성을 제거했습니다.

application.yml 수정 사항은 보안상 커밋에 포함하지 않았으며, 디스코드로 공유하겠습니다.