### PR TITLE
[#93] refactor: 메인 서버 실행 시 애뮬레이터 서버가 함께 실행되지 않도록 수정

### DIFF
--- a/back/main-server/build.gradle
+++ b/back/main-server/build.gradle
@@ -30,7 +30,7 @@ repositories {
 dependencies {
 
 	implementation project(':common') // 공통 모듈 연결
-	implementation project(':emulator-server')
+
 	// JWT 관련 라이브러리
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/back/main-server/src/main/java/com/example/mainserver/MainApplication.java
+++ b/back/main-server/src/main/java/com/example/mainserver/MainApplication.java
@@ -11,7 +11,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @SpringBootApplication(scanBasePackages = {
 		"com.example.mainserver",
 		"com.example.common",
-		"com.example.emulatorserver"
 })
 @EntityScan(basePackages = {
 		"com.example.mainserver.admin.domain",


### PR DESCRIPTION
## 변경 사항
- `@SpringBootApplication(scanBasePackages = {...})` 설정에서 `com.example.emulatorserver` 제거
- main-server의 build.gradle 내 의존성 정리 및 emulator-server 불필요 참조 제거

---

## 관련 이슈
- #93 