### PR TITLE
fix: CarEntity 변경에 따른 dto 및 로직수정

### DIFF
--- a/back/common/src/main/java/com/example/common/domain/car/CarEntity.java
+++ b/back/common/src/main/java/com/example/common/domain/car/CarEntity.java
@@ -48,8 +48,8 @@ public class CarEntity {
     @Column(name = "last_longitude")
     private String lastLongitude;
 
-    @Column(name = "emulator_id")
-    private Integer emulatorId; // 연결된 애뮬레이터 아이디
+    @Column(name = "login_id")
+    private String loginId;
 
     public void updateInfo(CarRequestDto carRequest) {
         if (carRequest.getBrand() != null && !carRequest.getBrand().isBlank()) {

--- a/back/common/src/main/java/com/example/common/domain/car/CarReader.java
+++ b/back/common/src/main/java/com/example/common/domain/car/CarReader.java
@@ -14,8 +14,6 @@ public interface CarReader  {
 
     Map<CarStatus, Long> getCountByStatus();
 
-    Optional<CarEntity> findByEmulatorId(Integer emulatorId);
-
     List<CarEntity> findByStatus(List<CarStatus> statuses);
 
 }

--- a/back/common/src/main/java/com/example/common/domain/car/CarStatus.java
+++ b/back/common/src/main/java/com/example/common/domain/car/CarStatus.java
@@ -1,5 +1,6 @@
 package com.example.common.domain.car;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 
 @Getter
@@ -14,6 +15,7 @@ public enum CarStatus {
         this.displayName = displayName;
     }
 
+    @JsonCreator
     // 한글 문자열로부터 enum 얻는 메서드
     public static CarStatus fromDisplayName(String displayName) {
         for (CarStatus status : values()) {

--- a/back/common/src/main/java/com/example/common/domain/car/config/CarStatusConverter.java
+++ b/back/common/src/main/java/com/example/common/domain/car/config/CarStatusConverter.java
@@ -12,7 +12,7 @@ public class CarStatusConverter implements Converter<String, CarStatus> {
         String v = source.trim();
         for (CarStatus s : CarStatus.values()) {
             if (s.getDisplayName().equals(v)) return s;       // "운행" -> DRIVING
-            if (s.name().equalsIgnoreCase(v)) return s;       // "DRIVING"도 허용(옵션)
+            if (s.name().equalsIgnoreCase(v)) return s;
         }
         throw new IllegalArgumentException("존재하지 않는 status: " + source);
     }

--- a/back/common/src/main/java/com/example/common/domain/car/config/CarStatusConverter.java
+++ b/back/common/src/main/java/com/example/common/domain/car/config/CarStatusConverter.java
@@ -1,0 +1,19 @@
+package com.example.common.domain.car.config;
+
+import com.example.common.domain.car.CarStatus;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CarStatusConverter implements Converter<String, CarStatus> {
+    @Override
+    public CarStatus convert(String source) {
+        if (source == null) return null;
+        String v = source.trim();
+        for (CarStatus s : CarStatus.values()) {
+            if (s.getDisplayName().equals(v)) return s;       // "운행" -> DRIVING
+            if (s.name().equalsIgnoreCase(v)) return s;       // "DRIVING"도 허용(옵션)
+        }
+        throw new IllegalArgumentException("존재하지 않는 status: " + source);
+    }
+}

--- a/back/common/src/main/java/com/example/common/infrastructure/car/CarReaderImpl.java
+++ b/back/common/src/main/java/com/example/common/infrastructure/car/CarReaderImpl.java
@@ -47,9 +47,6 @@ public class CarReaderImpl implements CarReader {
 
     }
 
-    public Optional<CarEntity> findByEmulatorId(Integer emulatorId){
-        return carRepository.findByEmulatorId(emulatorId);
-    }
 
     @Override
     public List<CarEntity> findByStatus(List<CarStatus> statuses) {

--- a/back/common/src/main/java/com/example/common/infrastructure/car/CarRepository.java
+++ b/back/common/src/main/java/com/example/common/infrastructure/car/CarRepository.java
@@ -15,8 +15,6 @@ public interface CarRepository extends JpaRepository<CarEntity, Integer> {
 
     Optional<CarEntity> findByCarNumber(String carNumber);
 
-    Optional<CarEntity> findByEmulatorId(Integer emulatorId);
-
     List<CarEntity> findByStatusIn(List<CarStatus> statuses); // 차량 상태 리스트 조회
 
     @Query("select c.status, count(c) from Car c group by c.status")

--- a/back/main-server/src/main/java/com/example/mainserver/car/controller/dto/CarDetailDto.java
+++ b/back/main-server/src/main/java/com/example/mainserver/car/controller/dto/CarDetailDto.java
@@ -10,7 +10,6 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-//@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 
 public class CarDetailDto {
 
@@ -32,6 +31,8 @@ public class CarDetailDto {
 
     private double sumDist;
 
+    private String loginId;
+
 
     public static CarDetailDto EntityToDto(CarEntity car){
         return CarDetailDto.builder()
@@ -44,6 +45,7 @@ public class CarDetailDto {
                 .sumDist(car.getSumDist())
                 .lastLatitude(car.getLastLatitude())
                 .lastLongitude(car.getLastLongitude())
+                .loginId(car.getLoginId())
                 .build();
 
     }

--- a/back/main-server/src/main/java/com/example/mainserver/car/controller/dto/CarSearchDto.java
+++ b/back/main-server/src/main/java/com/example/mainserver/car/controller/dto/CarSearchDto.java
@@ -28,7 +28,7 @@ public class CarSearchDto {
                 .carNumber(car.getCarNumber())
                 .brand(car.getBrand())
                 .model(car.getModel())
-                .status(car.getStatus().name())
+                .status(car.getStatus().getDisplayName())
                 .build();
 
     }

--- a/back/main-server/src/main/resources/application.yml
+++ b/back/main-server/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: ${DDL_AUTO:update}
+      ddl-auto: ${DDL_AUTO:none}
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
1. 차량 검색 식 dto 요청, 반환을 기존에 영어로 받는거에서 한글로 변경
2. CarEntity에서 emulator_id를 삭제 후 login_id로 변경 그리고 emulator 서버 삭제에 따른 emulator 로직 삭제