### PR TITLE
feat: 주행 기록 조회시 정렬 조건 추가

### DIFF
--- a/back/main-server/src/main/java/com/example/mainserver/auth/domain/AutoLoginRequest.java
+++ b/back/main-server/src/main/java/com/example/mainserver/auth/domain/AutoLoginRequest.java
@@ -1,0 +1,13 @@
+package com.example.mainserver.auth.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AutoLoginRequest {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/back/main-server/src/main/resources/mapper/DriveLogMapper.xml
+++ b/back/main-server/src/main/resources/mapper/DriveLogMapper.xml
@@ -34,6 +34,19 @@
             <when test="filter.sortBy == 'carNumber'">c.car_number</when>
             <when test="filter.sortBy == 'startTime'">start_time</when>
             <when test="filter.sortBy == 'endTime'">end_time</when>
+            <when test="filter.sortBy == 'brand'">c.brand</when>
+            <when test="filter.sortBy == 'model'">c.model</when>
+            <when test="filter.sortBy == 'startPoint'">start_point</when>
+            <when test="filter.sortBy == 'endPoint'">end_point</when>
+            <when test="filter.sortBy == 'driveDist'">dl.drive_dist</when>
+            <when test="filter.sortBy == 'status'">
+                CASE c.status
+                    WHEN 'IDLE' THEN 1
+                    WHEN 'MAINTENANCE' THEN 2
+                    WHEN 'DRIVING' THEN 3
+                    ELSE 4
+                END
+            </when>
         </choose>
         <choose>
         <when test="filter.sortOrder == 'ASC'">ASC</when>


### PR DESCRIPTION
1. 기존에 차량 번호, 주행 시작 날짜 종료 날짜로만 존재했던 정렬 조건을 브랜드, 모델명, 시작지점, 끝지점, 주행거리, 차량의 상태 순으로 정렬 조건을 추가하였습니다.
2. 차량의 상태 같은 경우 대기 -> 수리 -> 운행 순으로 오름차순 내림차순으로 정렬하도록 구현하였습니다.